### PR TITLE
Use margin instead of padding in footer links

### DIFF
--- a/app/static/error-pages/403.html
+++ b/app/static/error-pages/403.html
@@ -50,14 +50,18 @@
   </div><!-- ./wrap -->
   <div class="container" id="footer">
     <div class="ud-pd-sm">
-      <a class="right-pd-md" href='/about/'>关于我们</a>
-      <a class="right-pd-md" href='/blog/' style="display: none">网站博客</a>
-      <a class="right-pd-md" href='/community-rules/'>社区介绍</a>
-      <a class="right-pd-md hidden" href='/copyright/'>版权与隐私</a>
-      <a class="right-pd-md hidden" href='/report-bug/'>发现漏洞</a>
+      <a class="right-mg-md" href='/about/'>关于我们</a>
+      <a class="right-mg-md" href='/community-rules/'>社区规范</a>
+      <a class="right-mg-md" href='/report-review/'>投诉点评</a>
+      <a class="right-mg-md" href='/stats/'>站点统计</a>
+      <a class="right-mg-md" href='/stats/rankings/'>排行榜</a>
+      <a class="right-mg-md" href='/announcements/'>公告栏</a>
+      <a class="right-mg-md" href='/program/'>培养方案</a>
+      <a class="right-mg-md hidden" href='/copyright/'>版权与隐私</a>
+      <a class="right-mg-md hidden" href='/report-bug/'>发现漏洞</a>
       <span class="float-right hidden">
-        <a class="right-pd-sm">中文</a>
-        <a class="left-pd-sm">English</a>
+        <a class="right-mg-sm">中文</a>
+        <a class="left-mg-sm">English</a>
       </span>
     </div>
     <span class="footer-text text-muted">Copyright &copy; USTC评课社区 2022</span>

--- a/app/static/error-pages/404.html
+++ b/app/static/error-pages/404.html
@@ -50,14 +50,18 @@
   </div><!-- ./wrap -->
   <div class="container" id="footer">
     <div class="ud-pd-sm">
-      <a class="right-pd-md" href='/about/'>关于我们</a>
-      <a class="right-pd-md" href='/blog/' style="display: none">网站博客</a>
-      <a class="right-pd-md" href='/community-rules/'>社区介绍</a>
-      <a class="right-pd-md hidden" href='/copyright/'>版权与隐私</a>
-      <a class="right-pd-md hidden" href='/report-bug/'>发现漏洞</a>
+      <a class="right-mg-md" href='/about/'>关于我们</a>
+      <a class="right-mg-md" href='/community-rules/'>社区规范</a>
+      <a class="right-mg-md" href='/report-review/'>投诉点评</a>
+      <a class="right-mg-md" href='/stats/'>站点统计</a>
+      <a class="right-mg-md" href='/stats/rankings/'>排行榜</a>
+      <a class="right-mg-md" href='/announcements/'>公告栏</a>
+      <a class="right-mg-md" href='/program/'>培养方案</a>
+      <a class="right-mg-md hidden" href='/copyright/'>版权与隐私</a>
+      <a class="right-mg-md hidden" href='/report-bug/'>发现漏洞</a>
       <span class="float-right hidden">
-        <a class="right-pd-sm">中文</a>
-        <a class="left-pd-sm">English</a>
+        <a class="right-mg-sm">中文</a>
+        <a class="left-mg-sm">English</a>
       </span>
     </div>
     <span class="footer-text text-muted">Copyright &copy; USTC评课社区 2022</span>

--- a/app/static/error-pages/500.html
+++ b/app/static/error-pages/500.html
@@ -50,14 +50,18 @@
   </div><!-- ./wrap -->
   <div class="container" id="footer">
     <div class="ud-pd-sm">
-      <a class="right-pd-md" href='/about/'>关于我们</a>
-      <a class="right-pd-md" href='/blog/' style="display: none">网站博客</a>
-      <a class="right-pd-md" href='/community-rules/'>社区介绍</a>
-      <a class="right-pd-md hidden" href='/copyright/'>版权与隐私</a>
-      <a class="right-pd-md hidden" href='/report-bug/'>发现漏洞</a>
+      <a class="right-mg-md" href='/about/'>关于我们</a>
+      <a class="right-mg-md" href='/community-rules/'>社区规范</a>
+      <a class="right-mg-md" href='/report-review/'>投诉点评</a>
+      <a class="right-mg-md" href='/stats/'>站点统计</a>
+      <a class="right-mg-md" href='/stats/rankings/'>排行榜</a>
+      <a class="right-mg-md" href='/announcements/'>公告栏</a>
+      <a class="right-mg-md" href='/program/'>培养方案</a>
+      <a class="right-mg-md hidden" href='/copyright/'>版权与隐私</a>
+      <a class="right-mg-md hidden" href='/report-bug/'>发现漏洞</a>
       <span class="float-right hidden">
-        <a class="right-pd-sm">中文</a>
-        <a class="left-pd-sm">English</a>
+        <a class="right-mg-sm">中文</a>
+        <a class="left-mg-sm">English</a>
       </span>
     </div>
     <span class="footer-text text-muted">Copyright &copy; USTC评课社区 2022</span>

--- a/app/static/error-pages/502.html
+++ b/app/static/error-pages/502.html
@@ -50,14 +50,18 @@
   </div><!-- ./wrap -->
   <div class="container" id="footer">
     <div class="ud-pd-sm">
-      <a class="right-pd-md" href='/about/'>关于我们</a>
-      <a class="right-pd-md" href='/blog/' style="display: none">网站博客</a>
-      <a class="right-pd-md" href='/community-rules/'>社区介绍</a>
-      <a class="right-pd-md hidden" href='/copyright/'>版权与隐私</a>
-      <a class="right-pd-md hidden" href='/report-bug/'>发现漏洞</a>
+      <a class="right-mg-md" href='/about/'>关于我们</a>
+      <a class="right-mg-md" href='/community-rules/'>社区规范</a>
+      <a class="right-mg-md" href='/report-review/'>投诉点评</a>
+      <a class="right-mg-md" href='/stats/'>站点统计</a>
+      <a class="right-mg-md" href='/stats/rankings/'>排行榜</a>
+      <a class="right-mg-md" href='/announcements/'>公告栏</a>
+      <a class="right-mg-md" href='/program/'>培养方案</a>
+      <a class="right-mg-md hidden" href='/copyright/'>版权与隐私</a>
+      <a class="right-mg-md hidden" href='/report-bug/'>发现漏洞</a>
       <span class="float-right hidden">
-        <a class="right-pd-sm">中文</a>
-        <a class="left-pd-sm">English</a>
+        <a class="right-mg-sm">中文</a>
+        <a class="left-mg-sm">English</a>
       </span>
     </div>
     <span class="footer-text text-muted">Copyright &copy; USTC评课社区 2022</span>

--- a/app/templates/common-footer.html
+++ b/app/templates/common-footer.html
@@ -1,20 +1,20 @@
 <div class="container" id="footer">
     <div class="ud-pd-sm">
-      <a class="right-pd-md" href='/about/'>关于我们</a>
-      <a class="right-pd-md" href='/community-rules/'>社区规范</a>
-      <a class="right-pd-md" href='/report-review/'>投诉点评</a>
-      <a class="right-pd-md" href='/stats/'>站点统计</a>
-      <a class="right-pd-md" href='/stats/rankings/'>排行榜</a>
-      <a class="right-pd-md" href='/announcements/'>公告栏</a>
-      <a class="right-pd-md" href='/program/'>培养方案</a>
-      <a class="right-pd-md hidden" href='/copyright/'>版权与隐私</a>
-      <a class="right-pd-md hidden" href='/report-bug/'>发现漏洞</a>
+      <a class="right-mg-md" href='/about/'>关于我们</a>
+      <a class="right-mg-md" href='/community-rules/'>社区规范</a>
+      <a class="right-mg-md" href='/report-review/'>投诉点评</a>
+      <a class="right-mg-md" href='/stats/'>站点统计</a>
+      <a class="right-mg-md" href='/stats/rankings/'>排行榜</a>
+      <a class="right-mg-md" href='/announcements/'>公告栏</a>
+      <a class="right-mg-md" href='/program/'>培养方案</a>
+      <a class="right-mg-md hidden" href='/copyright/'>版权与隐私</a>
+      <a class="right-mg-md hidden" href='/report-bug/'>发现漏洞</a>
       {% if current_user.is_admin %}
-      <a class="right-pd-md" href='{{ url_for('admin.set_banner') }}'>Banner设置</a>
+      <a class="right-mg-md" href='{{ url_for('admin.set_banner') }}'>Banner设置</a>
       {% endif %}
       <span class="float-right hidden">
-        <a class="right-pd-sm">中文</a>
-        <a class="left-pd-sm">English</a>
+        <a class="right-mg-sm">中文</a>
+        <a class="left-mg-sm">English</a>
       </span>
     </div>
     <span class="footer-text text-muted">Copyright &copy; {{ date.year }} USTC评课社区</span>


### PR DESCRIPTION
Fix the display when links are clicked (or dragged) in Firefox.

When using `padding-right`:
![image](https://user-images.githubusercontent.com/2109893/227982873-64fb1516-1135-4420-b196-f62a6f5ec7a6.png)

And `margin-right`:
![image](https://user-images.githubusercontent.com/2109893/227983245-1e15c220-d69a-400c-bc97-988170c2397b.png)
