### PR TITLE
Use `sticky` at long review bottom bars

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -80,13 +80,13 @@ html, body { height: 100%; }
         margin: 20px 0;
         border: 1px #ddd dashed;
         border-radius: 4px;
-    }  
+    }
 }
 @media (max-width: 767px) {
     .select-box {
         padding-left: 8px;
         margin: 15px 0;
-    } 
+    }
 }
 
 p { line-height: 25px; word-wrap: break-word; }
@@ -99,6 +99,10 @@ p { line-height: 25px; word-wrap: break-word; }
 .rl-pd-sm, .rl-pd-md, .rl-pd-lg {
     overflow: hidden;
     word-wrap: break-word;
+}
+
+.ud-pd-md.display-folded {
+    overflow: visible;
 }
 
 .top-pd-sm { padding-top: 8px; }
@@ -405,7 +409,7 @@ a.nounderline:active { text-decoration: none; }
     right:30px;
     border-radius:7px;
     text-decoration:none;
-    display:none; 
+    display:none;
 }
 #gotop span {
     display:block;

--- a/app/templates/course.html
+++ b/app/templates/course.html
@@ -53,8 +53,8 @@
 .display-folded .fold-button::after {
   content: "\e113";
 }
-.fixed-bottom-bar {
-  position: fixed;
+.display-folded .bm-pd-md.grey {
+  position: sticky;
   width: 100%;
   bottom: 0;
   padding-top: 1em;
@@ -509,26 +509,7 @@
                     wrapperDiv.nextElementSibling.appendChild(foldButton);
                 }
             }
-            let requestId;
-            function checkContentPosition() {
-                const reviewContents = document.querySelectorAll('.review-wrapper');
-                const pageBottom = window.innerHeight;
-                reviewContents.forEach(reviewContent => {
-                    const reviewContentRect = reviewContent.getBoundingClientRect();
-                    const reviewContentTop = reviewContentRect.top;
-                    const reviewContentBottom = reviewContentRect.bottom;
-                    const bottomBar = reviewContent.nextElementSibling;
-                    const isOpen = reviewContent.parentNode.classList.contains('display-folded');
-                    if (reviewContentTop < pageBottom && reviewContentBottom > pageBottom && isOpen) {
-                        bottomBar.classList.add('fixed-bottom-bar');
-                    } else {
-                        bottomBar.classList.remove('fixed-bottom-bar');
-                    }
-                });
-                requestId = window.requestAnimationFrame(checkContentPosition);
-            }
             initFoldedElements();
-            requestId = window.requestAnimationFrame(checkContentPosition);
       </script>
 
       <!-- 右边栏 -->

--- a/app/templates/course.html
+++ b/app/templates/course.html
@@ -3,13 +3,11 @@
 
 <style>
 .folded {
-  display: -webkit-box;
-  -webkit-box-orient: vertical;
-  -webkit-line-clamp: 20;
+  max-height: 100vh;
   overflow: hidden;
 }
 .display-folded .review-content {
-  -webkit-line-clamp: unset !important;
+  max-height: unset;
 }
 .read-more {
   position: relative;
@@ -476,7 +474,7 @@
 
                 for (const reviewContent of reviewContents) {
                     const reviewContentHeight = reviewContent.scrollHeight;
-                    if (reviewContentHeight < 30 * parseFloat(window.getComputedStyle(reviewContent).lineHeight)) {
+                    if (reviewContentHeight < 1.5 * window.innerHeight) {
                         continue;
                     }
                     const wrapperDiv = document.createElement('div');


### PR DESCRIPTION
Taking advantage of `sticky` CSS property, we can avoid checking over all comments at each animation frame.

Related issue/PR:
- #50 
- #51 