### PR TITLE
修复隐藏主页后无法取消关注，并完善关注/粉丝列表

### DIFF
--- a/app/templates/followers.html
+++ b/app/templates/followers.html
@@ -11,10 +11,22 @@
 	（{{ user.follower_count }} 人）
       </div>
 
-      {% for user in user.followers %}
+      {% for follower in user.followers %}
       <div class="ud-pd-md dashed">
-	<img class="avatar-md circle" src="{{ user.avatar }}"/>
-	<a href={{ url_for('user.view_profile', user_id=user.id) }}><span class="right-pd-sm px16">{{ user.username }}</span></a>
+	<img class="avatar-md circle" src="{{ follower.avatar }}"/>
+	{% if follower.is_profile_hidden and (not current_user.is_authenticated or (current_user != follower and not current_user.is_admin)) %}
+	<span class="right-pd-sm px16">{{ follower.username }}</span>
+	<span class="gray px12">（主页未公开）</span>
+	{% else %}
+	<a href={{ url_for('user.view_profile', user_id=follower.id) }}><span class="right-pd-sm px16">{{ follower.username }}</span></a>
+	{% endif %}
+	{% if current_user.is_authenticated and current_user == user and follower != current_user %}
+	  {% if follower in current_user.users_following %}
+	  <span id="follow-state-{{ follower.id }}" class="gray px12"><span class="glyphicon glyphicon-heart" aria-hidden="true"></span> 已关注</span>
+	  {% else %}
+	  <span id="follow-state-{{ follower.id }}"><button onclick="follow_user({{ follower.id }})" class="btn btn-white btn-flat btn-xs btn-follow"><span class="glyphicon glyphicon-heart-empty" aria-hidden="true"></span> 回关 TA</button></span>
+	  {% endif %}
+	{% endif %}
       </div>
       {% endfor %}
 
@@ -23,4 +35,17 @@
 
   </div><!-- end float-element -->
 </div><!-- end container -->
+
+{% if current_user.is_authenticated and current_user == user %}
+<script type="text/javascript">
+function follow_user(user_id) {
+    $.post("{{ url_for('api.follow_user') }}", { user_id: user_id }, function(o) {
+        if (o.ok)
+            $('#follow-state-' + user_id).html('<span class="gray px12"><span class="glyphicon glyphicon-heart" aria-hidden="true"></span> 已关注</span>');
+        else
+            alert('关注用户失败：' + o.message);
+    }, 'json');
+}
+</script>
+{% endif %}
 {% endblock %}

--- a/app/templates/followings.html
+++ b/app/templates/followings.html
@@ -11,10 +11,18 @@
 	（{{ user.following_count }} 人）
       </div>
 
-      {% for user in user.users_following %}
-      <div class="ud-pd-md dashed">
-	<img class="avatar-md circle" src="{{ user.avatar }}"/>
-	<a href={{ url_for('user.view_profile', user_id=user.id) }}><span class="right-pd-sm px16">{{ user.username }}</span></a>
+      {% for followed in user.users_following %}
+      <div class="ud-pd-md dashed following-item" id="following-item-{{ followed.id }}">
+	<img class="avatar-md circle" src="{{ followed.avatar }}"/>
+	{% if followed.is_profile_hidden and (not current_user.is_authenticated or (current_user != followed and not current_user.is_admin)) %}
+	<span class="right-pd-sm px16">{{ followed.username }}</span>
+	<span class="gray px12">（主页未公开）</span>
+	{% else %}
+	<a href={{ url_for('user.view_profile', user_id=followed.id) }}><span class="right-pd-sm px16">{{ followed.username }}</span></a>
+	{% endif %}
+	{% if current_user.is_authenticated and current_user == user %}
+	<button onclick="unfollow_user({{ followed.id }})" class="btn btn-blue btn-flat btn-xs btn-unfollow"><span class="glyphicon glyphicon-heart" aria-hidden="true"></span> 取消关注</button>
+	{% endif %}
       </div>
       {% endfor %}
 
@@ -23,4 +31,17 @@
 
   </div><!-- end float-element -->
 </div><!-- end container -->
+
+{% if current_user.is_authenticated and current_user == user %}
+<script type="text/javascript">
+function unfollow_user(user_id) {
+    $.post("{{ url_for('api.unfollow_user') }}", { user_id: user_id }, function(o) {
+        if (o.ok)
+            $('#following-item-' + user_id).remove();
+        else
+            alert('取消关注用户失败：' + o.message);
+    }, 'json');
+}
+</script>
+{% endif %}
 {% endblock %}


### PR DESCRIPTION
## 问题

关注/取消关注按钮原本只存在于对方的个人主页 `profile.html`。当被关注者开启「彻底隐藏个人主页」（`is_profile_hidden`）后，关注者再也无法访问该页面，于是在 UI 上没有任何取消关注的入口（后端 `/api/user/unfollow/` 其实正常，只是前端够不到）。

## 改动

- **关注列表 `followings.html`**：为自己的关注列表每一项加「取消关注」按钮，复用 `/api/user/unfollow/`，成功后移除该行。无论对方是否隐藏主页都能取消。
- **粉丝列表 `followers.html`**：为「我还没关注的粉丝」加「回关 TA」按钮，复用 `/api/user/follow/`，成功后原地变「已关注」；已关注的粉丝显示「已关注」标识。不加强制移除粉丝功能。
- **修复死链**：两个列表中，若对方隐藏了主页，不再给指向被拦截页面的死链，改为纯文本 +「（主页未公开）」。
- **修复变量遮蔽**：两个模板的循环变量原本复用 `user`，会遮蔽页面所有者 `user`，分别改名为 `followed` / `follower`。

后端、API、模型均未改动。

🤖 Generated with [Claude Code](https://claude.com/claude-code)