### PR TITLE
Have the maintenance scripts ask for the index rebuilds they invalidate

### DIFF
--- a/app/search/builder.py
+++ b/app/search/builder.py
@@ -15,7 +15,7 @@ import logging
 import os
 import time
 from datetime import datetime, timedelta
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Sequence
 
 from .collections import ALL, DOCUMENT_SOURCES
 from .segment import SegmentWriter
@@ -81,15 +81,20 @@ def request_rebuild(app, collection: str) -> None:
         )
 
 
-def take_requests(app) -> List[str]:
-    """Collections with a pending request, clearing the markers.
+def take_requests(app, collections: Optional[Sequence[str]] = None) -> List[str]:
+    """Clear the pending-request markers for the given collections.
 
     Cleared *before* building, not after: a request arriving mid-build then
     recreates the marker and is served by the next run, where clearing
     afterwards would discard it.
+
+    ``collections`` must name exactly what the caller is about to build.
+    Clearing every marker regardless would drop a request that arrived for a
+    *different* collection between deciding what to build and starting -- a
+    window several seconds wide, since the application import sits in it.
     """
     taken = []
-    for collection in sorted(ALL):
+    for collection in sorted(ALL if collections is None else collections):
         try:
             os.unlink(_request_path(app, collection))
         except OSError:
@@ -214,7 +219,8 @@ def main(argv: Optional[list] = None) -> int:
         if args.if_needed:
             # Clear the markers now, before building: a request arriving while
             # a build runs recreates its marker and is served by the next run.
-            take_requests(app)
+            # Only for what we are actually about to build.
+            take_requests(app, names)
         for name in names:
             stats = build(app, db, name, progress=progress)
             if not args.quiet:

--- a/tests/clean_reviews_html.py
+++ b/tests/clean_reviews_html.py
@@ -2,6 +2,7 @@
 import sys
 sys.path.append('..')
 from app import app, db
+from app.search.builder import request_rebuild
 from app.models import Review
 from lxml.html.clean import Cleaner
 from app.utils import sanitize
@@ -26,3 +27,9 @@ with app.app_context():
 
             record_review_history(review, 'clean-html')
             db.session.commit()
+
+    # Review text is indexed. The freshness overlay keys on update_time,
+    # which this script deliberately does not bump -- a bulk cleanup should
+    # not resurface every review as recently updated -- so the index has to
+    # be rebuilt explicitly instead.
+    request_rebuild(app, 'reviews')

--- a/tests/dedup_course.py
+++ b/tests/dedup_course.py
@@ -3,6 +3,7 @@ import sys
 sys.path.append('..')  # fix import directory
 
 from app import app, db
+from app.search.builder import request_rebuild
 from app.models import Teacher
 
 ctx = app.test_request_context()
@@ -71,3 +72,8 @@ def dedup_teacher(teacher_id):
     print('Teacher information saved')
 
 dedup_teacher(int(sys.argv[1]))
+
+# Course names, teacher names and course codes are all indexed, so the
+# catalogue segment is stale after this. Ask for a rebuild; the timer
+# serves it within a couple of minutes.
+request_rebuild(app, 'courses')

--- a/tests/fix_at.py
+++ b/tests/fix_at.py
@@ -3,6 +3,7 @@ import sys
 sys.path.append('..')  # fix import directory
 
 from app import app, db
+from app.search.builder import request_rebuild
 from app.utils import editor_parse_at
 from app.models import Review, ReviewComment
 from app.views.api import record_review_comment_history
@@ -37,3 +38,9 @@ for comment in review_comments:
             user.notify('mention', comment, from_user=comment.author, time=comment.publish_time)
 
 db.session.commit()
+
+# Review text is indexed. The freshness overlay keys on update_time,
+# which this script deliberately does not bump -- a bulk cleanup should
+# not resurface every review as recently updated -- so the index has to
+# be rebuilt explicitly instead.
+request_rebuild(app, 'reviews')

--- a/tests/import_courses_catalog.py
+++ b/tests/import_courses_catalog.py
@@ -6,6 +6,7 @@ import sys
 sys.path.append("..")  # fix import directory
 
 from app import app, db
+from app.search.builder import request_rebuild
 from app.models import *
 from datetime import datetime
 import argparse
@@ -288,3 +289,7 @@ if __name__ == "__main__":
     with app.app_context():
         db.create_all()
         load_courses(args)
+        # Course names, teacher names and course codes are all indexed, so the
+        # catalogue segment is stale after this. Ask for a rebuild; the timer
+        # serves it within a couple of minutes.
+        request_rebuild(app, 'courses')

--- a/tests/import_db.py
+++ b/tests/import_db.py
@@ -3,6 +3,7 @@ import sys
 sys.path.append('..')  # fix import directory
 
 from app import app, db
+from app.search.builder import request_rebuild
 from app.models import *
 from datetime import datetime
 
@@ -587,3 +588,8 @@ with app.app_context():
     load_join_course()
     load_grad_students()
     load_grad_join_course()
+
+    # Course names, teacher names and course codes are all indexed, so the
+    # catalogue segment is stale after this. Ask for a rebuild; the timer
+    # serves it within a couple of minutes.
+    request_rebuild(app, 'courses')

--- a/tests/init_db.py
+++ b/tests/init_db.py
@@ -3,5 +3,12 @@ import sys
 sys.path.append('..')  # fix import directory
 
 from app import app, db
+from app.search import builder
+
 with app.app_context():
     db.create_all()
+    # Search reads a memory-mapped index, not the database, and returns 503
+    # until one exists.  Building it here keeps a fresh install working out of
+    # the box; on an empty database it is instant.
+    for stats in (builder.build(app, db, name) for name in sorted(builder.ALL)):
+        print('search index: %(collection)s, %(documents)d documents -> %(path)s' % stats)

--- a/tests/test_search_freshness.py
+++ b/tests/test_search_freshness.py
@@ -266,6 +266,19 @@ class TestCatalogueRebuildRequests(FreshnessTestCase):
         self.assertEqual(taken, ["courses"])
         self.assertEqual(builder.take_requests(app), ["courses"])
 
+    def test_taking_one_collection_leaves_the_other_request_alone(self):
+        """The builder clears markers before building, and several seconds pass
+        between deciding what to build and doing it.  A request for a
+        collection it is *not* building must survive that window."""
+        builder.request_rebuild(app, "courses")
+        builder.request_rebuild(app, "reviews")
+        self.assertEqual(builder.take_requests(app, ["courses"]), ["courses"])
+        self.assertEqual(
+            builder.take_requests(app),
+            ["reviews"],
+            "clearing one collection's request also dropped the other's",
+        )
+
     def test_repeated_requests_collapse_into_one_rebuild(self):
         for _ in range(20):
             builder.request_rebuild(app, "courses")


### PR DESCRIPTION
Follow-up to #67 and #68, from auditing every remaining writer of indexed data.

#67 removed the old `CourseSearchCache` / `ReviewSearchCache` per-write refresh and put a replacement (`request_rebuild()`) only on the two routes it had touched — `add_teacher` and `remove_teacher`. Five other scripts still write indexed data and said nothing to the index.

## What was stale, and why

| script | writes | consequence |
|---|---|---|
| `import_courses_catalog.py` | creates courses + teachers, sets `course.teachers` | catalogue segment wrong |
| `import_db.py` | creates courses + teachers, appends teachers | catalogue segment wrong |
| `dedup_course.py` | merges teachers, reassigns `course.teachers` | catalogue segment wrong |
| `clean_reviews_html.py` | rewrites review content in bulk | index keeps matching the old text |
| `fix_at.py` | rewrites review content in bulk | index keeps matching the old text |

The catalogue has no freshness overlay, so the first three persisted until the hourly rebuild.

The two review scripts are subtler and worth spelling out. The overlay keys on `reviews.update_time`, and neither script bumps it — which is *correct*, since a bulk cleanup shouldn't resurface every review as recently updated. But that means the overlay never notices them, and the index goes on matching text that has been edited away. So bulk review rewrites are exactly the case where a review rebuild does need requesting, even though ordinary review writes never do.

Each script now requests the rebuild it invalidates.

## A builder bug this surfaced

`take_requests()` cleared the markers for **every** collection, not just the ones about to be built — and the application import sits between deciding what to build and clearing them. That is several seconds during which a request for the *other* collection could arrive and be silently dropped, its rebuild never happening. It now clears only what it is building, with a regression test.

## Fresh installs

`init_db.py` now builds the index. Search reads a memory-mapped index rather than the database and returns 503 until one exists, so a fresh install was left with search broken until someone read the deployment notes. On an empty database it is instant.

## Checked and deliberately not changed

`import_programs.py` (only `ProgramCourse` mappings) and `import-teacher-photo.py` (photos, not names) touch nothing indexed. `import_courses_new.py` and the add/remove-teacher routes were already covered by #67.

## Verification

73 tests pass (freshness suite 16 → 17). Verified end to end that requesting both collections, then building only courses, leaves the reviews request intact for the next run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)