### PR TITLE
Rebuild the search index daily, not hourly

### DIFF
--- a/DEPLOYMENT_INSTRUCTIONS.md
+++ b/DEPLOYMENT_INSTRUCTIONS.md
@@ -63,9 +63,12 @@ systemctl list-timers ustc-course-search-index.timer
 The timer fires every two minutes but the unit is gated by an `ExecCondition`
 that costs milliseconds, so it does nothing unless there is work:
 
-* **Reviews** only ever rebuild on age (hourly). Everything written or edited
-  since the last build is served exactly by the freshness overlay in
-  `app/search/delta.py`, so the rebuild is just what keeps that overlay small.
+* **Reviews** only ever rebuild on age, once a day. Everything written or
+  edited since the last build is served exactly by the freshness overlay in
+  `app/search/delta.py`, so the rebuild is just what keeps that overlay small —
+  and this site takes years to accumulate the reviews that would fill it.
+  Rebuilding them hourly, as originally shipped, spent about 7% of a core
+  continuously to no effect.
 * **The catalogue has no overlay**, so course edits that change indexed text —
   adding or removing a teacher, or a catalogue import — call
   `app.search.builder.request_rebuild()`, which drops a marker the timer picks
@@ -73,7 +76,7 @@ that costs milliseconds, so it does nothing unless there is work:
 
 That marker file is written by the web process, so the index directory must be
 writable by the `icourse` user. If it isn't, the request is logged and dropped
-and the edit simply waits for the hourly rebuild — it never fails the edit.
+and the edit waits for the daily rebuild instead — it never fails the edit.
 
 ## Step 5: Restart the application
 
@@ -146,6 +149,11 @@ cd /srv/ustc-course && sudo -u icourse env PYTHONPATH=. /usr/bin/python3 -m app.
 
 **Disk.** Roughly 130 MB for both segments, plus the same again transiently
 while a rebuild writes its temporary file. The builder peaks around 400 MB RSS.
+
+**Rebuild cadence** is `MAX_AGE` in `app/search/builder.py`, per collection.
+The `ExecCondition` in the service unit duplicates the threshold as a cheap
+pre-filter; keep its `-mmin` just *below* the smallest `MAX_AGE`, since too low
+only wastes a process start while too high would skip a due rebuild.
 
 **If the timer stops.** Searches stay *correct* — the overlay covers the gap —
 but get slower as it grows. Past `MAX_DELTA_ROWS` the overlay stops expanding

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ PYTHONPATH=. python3 -m app.search.builder
 索引未构建时搜索会返回 503。
 
 新发布和修改的点评不必等待重建：```app/search/delta.py``` 会直接从数据库读取
-自上次构建以来变化的行，因此点评索引每小时重建一次即可。
+自上次构建以来变化的行，因此点评索引每天重建一次即可（见 ```app/search/builder.py``` 中的 ```MAX_AGE```）。
 
 课程索引没有这套机制，所以修改课程教师、或导入课程目录时，代码会调用
 ```app.search.builder.request_rebuild()``` 请求重建，定时器会在几分钟内执行

--- a/app/search/builder.py
+++ b/app/search/builder.py
@@ -1,10 +1,10 @@
 """Builds index segments from the database.
 
-Runs out of process, on a timer.  A full rebuild of both collections takes
-well under a minute, which is why there is no incremental-update machinery to
+Runs out of process, on a timer.  There is no incremental-update machinery to
 get wrong: the index is simply replaced, and everything written since the build
 started is served by the freshness overlay in :mod:`app.search.delta` until the
-next rebuild catches up.
+next rebuild catches up.  On production that costs about twenty seconds for the
+catalogue and five minutes for the reviews.
 
 The watermark stored in the segment is the instant *before* the build began, so
 a row edited while the build is running is covered by the overlay rather than
@@ -22,6 +22,32 @@ from .segment import SegmentWriter
 
 
 _REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+#: How stale a segment may become before the timer rebuilds it even though
+#: nothing asked for one.  Per collection, because the two are safety nets
+#: against different things:
+#:
+#: ``courses``  Rebuilds are event-driven -- every route and script that edits
+#:              indexed catalogue data calls :func:`request_rebuild`.  The age
+#:              path only catches what bypasses that: a direct database edit,
+#:              or a marker that could not be written.
+#: ``reviews``  Has no event path and does not need one; the overlay serves
+#:              every row written since the build, exactly.  Rebuilding only
+#:              bounds how much the overlay carries, and this site accumulates
+#:              its fifty thousand reviews over *years* -- a day's writes are a
+#:              few dozen, against MAX_DELTA_ROWS of five thousand.
+#:
+#: An hour was the original guess for both.  Measured over twelve hours of
+#: production it cost about forty-five minutes of CPU -- some 7% of a core,
+#: continuously -- to rebuild an index that nothing had invalidated, because
+#: the overlay was already serving the handful of new reviews correctly.
+MAX_AGE = {
+    "courses": 86400.0,
+    "reviews": 86400.0,
+}
+
+#: Used for a collection with no entry above.
+DEFAULT_MAX_AGE = 86400.0
 
 
 def default_segment_dir() -> str:
@@ -103,18 +129,23 @@ def take_requests(app, collections: Optional[Sequence[str]] = None) -> List[str]
     return taken
 
 
-def _work_pending(index_dir: str, max_age: float) -> List[str]:
-    """Which collections need building, decided from the filesystem alone."""
+def _work_pending(index_dir: str, max_age: Optional[float] = None) -> List[str]:
+    """Which collections need building, decided from the filesystem alone.
+
+    ``max_age`` overrides :data:`MAX_AGE` for every collection; leave it unset
+    to use each collection's own limit.
+    """
     needed = []
     for collection in sorted(ALL):
         if os.path.exists(os.path.join(index_dir, "%s.rebuild" % collection)):
             needed.append(collection)
             continue
+        limit = max_age if max_age is not None else MAX_AGE.get(collection, DEFAULT_MAX_AGE)
         try:
             age = time.time() - os.stat(os.path.join(index_dir, "%s.seg" % collection)).st_mtime
         except OSError:
             age = float("inf")
-        if age >= max_age:
+        if age >= limit:
             needed.append(collection)
     return needed
 
@@ -191,8 +222,10 @@ def main(argv: Optional[list] = None) -> int:
     parser.add_argument(
         "--max-age",
         type=float,
-        default=3600.0,
-        help="with --if-needed, rebuild a segment older than this many seconds",
+        default=None,
+        help="with --if-needed, rebuild a segment older than this many seconds, "
+        "overriding the per-collection defaults (%s)"
+        % ", ".join("%s=%gs" % kv for kv in sorted(MAX_AGE.items())),
     )
     args = parser.parse_args(argv)
 

--- a/tests/test_search_freshness.py
+++ b/tests/test_search_freshness.py
@@ -284,6 +284,25 @@ class TestCatalogueRebuildRequests(FreshnessTestCase):
             builder.request_rebuild(app, "courses")
         self.assertEqual(builder.take_requests(app), ["courses"])
 
+    def test_age_limits_are_per_collection_and_overridable(self):
+        index_dir = builder.segment_dir(app)
+        # Fresh segments, nothing requested: no work.
+        self.assertEqual(builder._work_pending(index_dir), [])
+        # A zero limit makes everything overdue, which is how the CLI override
+        # forces a rebuild.
+        self.assertEqual(builder._work_pending(index_dir, max_age=0), sorted(builder.ALL))
+        # Every collection must have a limit, whether or not it is named.
+        for name in builder.ALL:
+            limit = builder.MAX_AGE.get(name, builder.DEFAULT_MAX_AGE)
+            self.assertGreater(limit, 0)
+
+    def test_a_request_beats_the_age_limit(self):
+        """A requested rebuild must happen now, not when the segment ages out."""
+        index_dir = builder.segment_dir(app)
+        self.assertEqual(builder._work_pending(index_dir), [])
+        builder.request_rebuild(app, "courses")
+        self.assertEqual(builder._work_pending(index_dir), ["courses"])
+
     def test_segment_age_reports_a_built_segment(self):
         self.assertLess(builder.segment_age(app, "reviews"), float("inf"))
         self.assertEqual(builder.segment_age(app, "nonexistent"), float("inf"))

--- a/ustc-course-search-index.service
+++ b/ustc-course-search-index.service
@@ -19,9 +19,14 @@ Environment=INDEX_DIR=/srv/ustc-course/data/search-index
 # there is no work.  This shell test costs milliseconds and skips the unit.
 #
 # It is only a pre-filter: --if-needed below re-checks authoritatively, so the
-# two can disagree without anything being built wrongly.  Keep the -mmin value
-# at or below the builder's --max-age.
-ExecCondition=/bin/sh -c 'ls $INDEX_DIR/*.rebuild >/dev/null 2>&1 || [ ! -f $INDEX_DIR/reviews.seg ] || [ ! -f $INDEX_DIR/courses.seg ] || [ -n "$(find $INDEX_DIR -maxdepth 1 -name \\*.seg -mmin +59 -print -quit)" ]'
+# two can disagree without anything being built wrongly -- but only in the safe
+# direction.  Keep -mmin just *below* the smallest MAX_AGE in app/search/builder.py
+# (currently 86400s = 1440min): too low merely starts Python to find no work,
+# whereas too high would skip a rebuild that was actually due.  At 1439 the two
+# disagree for one minute a day; at the previous 59-vs-60 they disagreed for one
+# minute an hour, which is where fifteen pointless starts per twelve hours came
+# from.
+ExecCondition=/bin/sh -c 'ls $INDEX_DIR/*.rebuild >/dev/null 2>&1 || [ ! -f $INDEX_DIR/reviews.seg ] || [ ! -f $INDEX_DIR/courses.seg ] || [ -n "$(find $INDEX_DIR -maxdepth 1 -name \\*.seg -mmin +1439 -print -quit)" ]'
 
 ExecStart=/usr/bin/python3 -m app.search.builder --quiet --if-needed
 

--- a/ustc-course-search-index.timer
+++ b/ustc-course-search-index.timer
@@ -6,11 +6,14 @@ Description=Rebuild the USTC iCourse search index when it needs it
 # unless there is work: either a segment has aged past --max-age (one hour) or
 # the application has asked for a rebuild.
 #
-# Reviews only ever take the hourly path -- everything written since the last
-# build is served exactly by the freshness overlay in app/search/delta.py, so
-# the rebuild is just what keeps that overlay small.  The catalogue has no
-# overlay, so an administrator changing a course's teachers requests a rebuild
-# directly and it lands within a couple of minutes rather than within an hour.
+# Firing often is what makes a *requested* rebuild land within a couple of
+# minutes: an administrator changing a course's teachers asks for one directly,
+# because the catalogue has no freshness overlay.
+#
+# Nothing is rebuilt merely because time passed until it is a day old (see
+# MAX_AGE in app/search/builder.py).  Reviews do not need it sooner -- the
+# overlay in app/search/delta.py serves everything written since the last build,
+# exactly -- and rebuilding them hourly cost ~7% of a core doing nothing useful.
 #
 # OnCalendar, not OnUnitActiveSec: the latter arms itself relative to the last
 # time the service was *active*, and a run skipped by ExecCondition never


### PR DESCRIPTION
Tuning from watching #67 run overnight on production.

## The measurement

Twelve hours of timer activity, classified by CPU consumed:

| runs | what | cost each |
|---|---|---|
| 9 | reviews rebuild | **~5 min** |
| 10 | courses rebuild | ~24 s |
| 15 | started, found no work | ~6 s |

**~45 minutes of CPU per 12 hours — roughly 7% of a core, continuously.**

## Why hourly was wrong

I picked it by assumption, and the assumption contradicts the design. The whole point of the freshness overlay is that reviews *don't* need rebuilding to stay current: every row written or edited since the last build is read from the database and matched directly, exactly. The rebuild only bounds how much the overlay carries.

This site accumulates its 50,000 reviews over *years*. A day's writes are a few dozen — against a `MAX_DELTA_ROWS` ceiling of 5,000. At deploy the overlay was carrying **0 rows**. So the hourly rebuild was buying nothing that the overlay wasn't already giving for free.

## The change

`MAX_AGE` is now per collection, at a day each. Per collection rather than a single number because they are safety nets against different things:

- **courses** — rebuilds are event-driven; every route and script that edits indexed catalogue data calls `request_rebuild()`. The age path only catches what bypasses that (a direct database edit, or a marker that couldn't be written).
- **reviews** — no event path and none needed; the overlay covers it. Age is purely about bounding overlay size.

`--max-age` still overrides both, which is how a forced rebuild is spelled.

## The 15 pointless starts

Separately, the unit's `ExecCondition` tested `-mmin +59` against the builder's 3600 s limit, so for one minute in every hour it started Python only for the builder to find nothing to do. At `-mmin +1439` against 86400 s the same disagreement lasts one minute a day.

The pre-filter must stay just *below* the builder's limit — too low merely wastes a process start, too high would skip a rebuild that was due. That's now stated in the unit and in `DEPLOYMENT_INSTRUCTIONS.md`.

## Effect

~45 min of CPU per 12 h → ~5 min per day. **No change to what a search returns**, since the overlay is what makes results current either way.

## Verification

82 tests pass (freshness 17 → 19, covering per-collection limits, the `--max-age` override, and a request beating the age limit). Confirmed the gate returns *skip* on fresh segments, *run* on a 25-hour-old segment, and *run* on a pending request; and that `--max-age 0` still forces a build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)