### PR TITLE
Contain bidi/invisible characters in display; validate homepage URL schemes

### DIFF
--- a/app/models/user.py
+++ b/app/models/user.py
@@ -112,7 +112,7 @@ class User(db.Model, UserMixin):
 
     @property
     def link(self):
-        return Markup('<a href="' + self.url + '">') + Markup.escape(self.username) + Markup('</a>')
+        return Markup('<a href="' + self.url + '"><bdi>') + Markup.escape(self.username) + Markup('</bdi></a>')
 
     @property
     def is_blocked_now(self):
@@ -536,7 +536,7 @@ class Teacher(db.Model):
 
     @property
     def link(self):
-        return Markup('<a href="' + self.url + '">') + Markup.escape(self.name) + Markup('</a>')
+        return Markup('<a href="' + self.url + '"><bdi>') + Markup.escape(self.name) + Markup('</bdi></a>')
 
     @property
     def image(self):

--- a/app/templates/announcements.html
+++ b/app/templates/announcements.html
@@ -19,7 +19,7 @@
         <p class="text-muted ck-content">{{ announcement.content|safe }}</p>
 
         <div class="grey bm-pd-md">
-	      <a href="{{ url_for('user.view_profile', user_id=announcement.author.id) }}">{{ announcement.author.username }}</a> 发表于
+	      <a href="{{ url_for('user.view_profile', user_id=announcement.author.id) }}"><bdi>{{ announcement.author.username }}</bdi></a> 发表于
           <span class="localtime" style="display: none;">{{ announcement.publish_time|utctime }}</span>
 	      {% if announcement.publish_time != announcement.update_time %}
 	      <span>（最后修改于</span> <span class="localtime" style="display: none;">{{ announcement.update_time|utctime }}</span><span>）</span>

--- a/app/templates/course-edit.html
+++ b/app/templates/course-edit.html
@@ -68,7 +68,7 @@
           <btn class="btn btn-link float-right"><a href="javascript: remove_teacher({{ teacher.id }});">从课程中删除教师</a></btn>
           {% endif %}
           {% endif %}
-          <h3 class="blue"><a href="{{ url_for('teacher.view_profile', teacher_id=teacher.id) }}">{{ teacher.name }}</a></h3>
+          <h3 class="blue"><a href="{{ url_for('teacher.view_profile', teacher_id=teacher.id) }}"><bdi>{{ teacher.name }}</bdi></a></h3>
           <p>{{ teacher.dept.name }}</p>
           <p>教师主页：
             {% if teacher.homepage and teacher.homepage != 'http://' %}

--- a/app/templates/course-profile-history.html
+++ b/app/templates/course-profile-history.html
@@ -23,7 +23,7 @@
       	    </p>
             <p>课程简介：{% if history.introduction %}{{ history.introduction|safe }}{% else %}暂无{% endif %}</p>
             <div>
-              <span class="text-muted">贡献者：<a href="{{ url_for('user.view_profile', user_id=history.author) }}">{{ history.author_user.username }}</a></span>
+              <span class="text-muted">贡献者：<a href="{{ url_for('user.view_profile', user_id=history.author) }}"><bdi>{{ history.author_user.username }}</bdi></a></span>
               <span class="text-muted pull-right">编辑时间：<span class="localtime" style="display: none;">{{ history.update_time|utctime }}</span></span>
             </div>
       	  </div>

--- a/app/templates/course.html
+++ b/app/templates/course.html
@@ -373,7 +373,7 @@
               {% if review.is_anonymous %}
               匿名用户
               {% else %}
-              <a href={{ url_for('user.view_profile', user_id=review.author.id) }}>{{ review.author.username }}</a>
+              <a href={{ url_for('user.view_profile', user_id=review.author.id) }}><bdi>{{ review.author.username }}</bdi></a>
               {% endif %}
             </span>
 
@@ -493,7 +493,7 @@
           <div class="bm-pd-md" id="review-upvotes-{{ review.id }}">
             <p style="line-break: loose;">
               <span class="glyphicon glyphicon-thumbs-up blue" aria-hidden="true"></span>
-              {% for upvote_user in review.upvote_users %}{% if upvote_user != review.upvote_users[0] %}、{% endif %}<a href={{ url_for('user.view_profile', user_id=upvote_user.id) }}>{{ upvote_user.username }}</a>{% endfor %}
+              {% for upvote_user in review.upvote_users %}{% if upvote_user != review.upvote_users[0] %}、{% endif %}<a href={{ url_for('user.view_profile', user_id=upvote_user.id) }}><bdi>{{ upvote_user.username }}</bdi></a>{% endfor %}
             </p>
           </div>
           {% endif %}
@@ -565,7 +565,7 @@
               {% endif %}
             {% endif %}
           {% endif %}
-          <h3 class="blue"><a href="{{ url_for('teacher.view_profile', teacher_id=teacher.id) }}">{{ teacher.name }}</a></h3>
+          <h3 class="blue"><a href="{{ url_for('teacher.view_profile', teacher_id=teacher.id) }}"><bdi>{{ teacher.name }}</bdi></a></h3>
           <p>{{ teacher.dept.name }}</p>
           <p>教师主页：
             {% if teacher.homepage and teacher.homepage != 'http://' %}
@@ -615,7 +615,7 @@
 
         {% for teacher in course.teachers %}
         <div class="ud-pd-md dashed">
-          <h4 class="blue">{{ teacher.name }}老师的其他课</h5>
+          <h4 class="blue"><bdi>{{ teacher.name }}</bdi>老师的其他课</h5>
           {% for rel_course in course.same_teacher_courses(teacher) %}
           {% if rel_course != course %}
           <div class="ud-pd-sm">

--- a/app/templates/data.html
+++ b/app/templates/data.html
@@ -66,7 +66,7 @@
           </tr>
         {% for user in users %}
           <tr>
-            <td><a href="{{ url_for('user.view_profile', user_id=user.id) }}" target="_blank">{{ user.username }}</a></td>
+            <td><a href="{{ url_for('user.view_profile', user_id=user.id) }}" target="_blank"><bdi>{{ user.username }}</bdi></a></td>
             <td>{{ user.reviews_count }}</td>
 	    <td>{{ user.review_upvotes_count }}</td>
           </tr>
@@ -85,7 +85,7 @@
         {% for review in reviews %}
           <tr>
             <td><a href="{{ url_for('course.view_course', course_id=review.course_id) }}#review-{{ review.review_id }}" target="_blank">{{ review.course_name }}</a></td>
-            <td><a href="{{ url_for('user.view_profile', user_id=review.author_id) }}" target="_blank">{{ review.author_username }}</a></td>
+            <td><a href="{{ url_for('user.view_profile', user_id=review.author_id) }}" target="_blank"><bdi>{{ review.author_username }}</bdi></a></td>
             <td>{{ review.review_upvotes_count }}</td>
           </tr>
         {% endfor %}

--- a/app/templates/email/crisis-alert.html
+++ b/app/templates/email/crisis-alert.html
@@ -11,7 +11,7 @@
 <p><b>课程：</b>{{ info.course_name }}</p>
 <p><b>点评链接：</b><a href="{{ info.review_url }}">{{ info.review_url }}</a></p>
 <p><b>作者邮箱：</b>{{ info.author_email }}</p>
-<p><b>作者用户名：</b>{{ info.author_username }}{% if info.is_anonymous %}（该点评为匿名发表）{% endif %}</p>
+<p><b>作者用户名：</b><bdi>{{ info.author_username }}</bdi>{% if info.is_anonymous %}（该点评为匿名发表）{% endif %}</p>
 <p><b>检测时间（UTC）：</b>{{ info.time }}</p>
 
 <p><b>点评内容：</b></p>

--- a/app/templates/email/review-author-profile.html
+++ b/app/templates/email/review-author-profile.html
@@ -17,7 +17,7 @@
 
 <p><b>作者资料</b></p>
 <p><b>用户 ID：</b>{{ info.author_id }}</p>
-<p><b>用户名：</b>{{ info.author_username }}</p>
+<p><b>用户名：</b><bdi>{{ info.author_username }}</bdi></p>
 <p><b>注册邮箱：</b>{{ info.author_email }}</p>
 <p><b>注册时间（UTC）：</b>{{ info.register_time }}</p>
 <p><b>最近登录时间（UTC）：</b>{{ info.last_login_time or '无记录' }}</p>

--- a/app/templates/follow-course.html
+++ b/app/templates/follow-course.html
@@ -7,7 +7,7 @@
 
     <div class="bm-pd-lg">
       <div class="inline-h3">
-        <span class="blue h3"><a href="{{ url_for('user.view_profile', user_id=user.id) }}">{{ user.username }}</a> 关注</span>
+        <span class="blue h3"><a href="{{ url_for('user.view_profile', user_id=user.id) }}"><bdi>{{ user.username }}</bdi></a> 关注</span>
         （{{ user.courses_following_count }}门）
       </div>
 

--- a/app/templates/followers.html
+++ b/app/templates/followers.html
@@ -7,7 +7,7 @@
 
     <div class="bm-pd-lg">
       <div class="inline-h3">
-        <span class="blue h4"><strong> {{ user.username }} 被关注 </strong></span>
+        <span class="blue h4"><strong> <bdi>{{ user.username }}</bdi> 被关注 </strong></span>
 	（{{ user.follower_count }} 人）
       </div>
 
@@ -15,10 +15,10 @@
       <div class="ud-pd-md dashed">
 	<img class="avatar-md circle" src="{{ follower.avatar }}"/>
 	{% if follower.is_profile_hidden and (not current_user.is_authenticated or (current_user != follower and not current_user.is_admin)) %}
-	<span class="right-pd-sm px16">{{ follower.username }}</span>
+	<span class="right-pd-sm px16"><bdi>{{ follower.username }}</bdi></span>
 	<span class="gray px12">（主页未公开）</span>
 	{% else %}
-	<a href={{ url_for('user.view_profile', user_id=follower.id) }}><span class="right-pd-sm px16">{{ follower.username }}</span></a>
+	<a href={{ url_for('user.view_profile', user_id=follower.id) }}><span class="right-pd-sm px16"><bdi>{{ follower.username }}</bdi></span></a>
 	{% endif %}
 	{% if current_user.is_authenticated and current_user == user and follower != current_user %}
 	  {% if follower in current_user.users_following %}

--- a/app/templates/followings.html
+++ b/app/templates/followings.html
@@ -7,7 +7,7 @@
 
     <div class="bm-pd-lg">
       <div class="inline-h3">
-        <span class="blue h4"><strong>{{ user.username }} 的关注 </strong></span>
+        <span class="blue h4"><strong><bdi>{{ user.username }}</bdi> 的关注 </strong></span>
 	（{{ user.following_count }} 人）
       </div>
 
@@ -15,10 +15,10 @@
       <div class="ud-pd-md dashed following-item" id="following-item-{{ followed.id }}">
 	<img class="avatar-md circle" src="{{ followed.avatar }}"/>
 	{% if followed.is_profile_hidden and (not current_user.is_authenticated or (current_user != followed and not current_user.is_admin)) %}
-	<span class="right-pd-sm px16">{{ followed.username }}</span>
+	<span class="right-pd-sm px16"><bdi>{{ followed.username }}</bdi></span>
 	<span class="gray px12">（主页未公开）</span>
 	{% else %}
-	<a href={{ url_for('user.view_profile', user_id=followed.id) }}><span class="right-pd-sm px16">{{ followed.username }}</span></a>
+	<a href={{ url_for('user.view_profile', user_id=followed.id) }}><span class="right-pd-sm px16"><bdi>{{ followed.username }}</bdi></span></a>
 	{% endif %}
 	{% if current_user.is_authenticated and current_user == user %}
 	<button onclick="unfollow_user({{ followed.id }})" class="btn btn-blue btn-flat btn-xs btn-unfollow"><span class="glyphicon glyphicon-heart" aria-hidden="true"></span> 取消关注</button>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -26,7 +26,7 @@
           {% if review.is_anonymous %}
           <span class="blue">匿名用户</span>
           {% else %}
-	      <a href="{{ url_for('user.view_profile', user_id=review.author.id) }}">{{ review.author.username }}</a>
+	      <a href="{{ url_for('user.view_profile', user_id=review.author.id) }}"><bdi>{{ review.author.username }}</bdi></a>
           {% endif %}
 	      {% if review.publish_time == review.update_time %}点评了{% else %}更新了点评{% endif %}
               <a href="{{ url_for('course.view_course', course_id=review.course.id) }}">{{ review.course.name }}{% if review.course.teachers %}（{{ review.course.teacher_names_display }}）{% endif %}</a>

--- a/app/templates/join-course.html
+++ b/app/templates/join-course.html
@@ -7,7 +7,7 @@
 
     <div class="bm-pd-lg">
       <div class="inline-h3">
-          <span class="blue h3"><a href="{{ url_for('user.view_profile', user_id=user.id) }}">{{ user.username }}</a> 学过</span>
+          <span class="blue h3"><a href="{{ url_for('user.view_profile', user_id=user.id) }}"><bdi>{{ user.username }}</bdi></a> 学过</span>
         （{{ user.classes_joined_count }}门）
       </div>
 

--- a/app/templates/layout.html
+++ b/app/templates/layout.html
@@ -8,7 +8,7 @@
       <div class="navbar-header">
         {% if current_user.is_authenticated %}
         <button type="button" class="mobile btn btn-default navbar-btn pull-right right-mg-md" style="outline:none" data-toggle="collapse" data-target="#navbar" aria-expanded="false" aria-controls="navbar">
-          {{ current_user.username }} <span class="caret"></span>
+          <bdi>{{ current_user.username }}</bdi> <span class="caret"></span>
         </button>
         {% else %}
         <button type="button" class="mobile btn btn-default navbar-btn pull-right right-mg-md" style="outline:none" data-toggle="modal" data-target="#signin">登录</button>
@@ -64,7 +64,7 @@
           </li>
 
           <li class="dropdown">
-            <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">{{ current_user.username }}<span class="caret"></span></a>
+            <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false"><bdi>{{ current_user.username }}</bdi><span class="caret"></span></a>
             <ul class="dropdown-menu" role="menu">
               <li><a href="{{ url_for('user.view_profile', user_id=current_user.id) }}">个人主页</a></li>
               <li><a href="{{ url_for('user.account_settings') }}">设置</a></li>

--- a/app/templates/profile.html
+++ b/app/templates/profile.html
@@ -130,14 +130,14 @@
     <div class="col-md-4 right-col">
       <div class="ud-pd-md dashed">
 	<img class="avatar-lg circle" src="{{ user.avatar }}"/>
-	<h3 class="blue">{{ user.username }}</h3>
+	<h3 class="blue"><bdi>{{ user.username }}</bdi></h3>
       {% if user.is_teacher %}<span class="label label-success px14">老师</span>{% endif %}
         <ul class="list-unstyled dark-grey">
-          <li class="ud-pd-sm">简介：{{ user.description }}</li>
+          <li class="ud-pd-sm">简介：<bdi>{{ user.description }}</bdi></li>
           <li class="ud-pd-sm" style="overflow:hidden">博客：
             {% if user.homepage and user.homepage != 'http://' %}
-            <a href="{{ user.homepage }}">
-              <span class="glyphicon glyphicon-link" aria-hidden="true"></span> {{ user.homepage }}
+            <a href="{{ user.homepage | safe_url }}">
+              <span class="glyphicon glyphicon-link" aria-hidden="true"></span> <bdi>{{ user.homepage }}</bdi>
             </a>
             {% else %}
             暂无

--- a/app/templates/ranking.html
+++ b/app/templates/ranking.html
@@ -151,8 +151,7 @@
             {% if review.is_anonymous %}
             <td>匿名用户</td>
             {% else %}
-            <td><a href="{{ url_for('user.view_profile', user_id=review.author_id) }}" target="_blank">{{
-                review.author_username }}</a></td>
+            <td><a href="{{ url_for('user.view_profile', user_id=review.author_id) }}" target="_blank"><bdi>{{ review.author_username }}</bdi></a></td>
             {% endif %}
             <td>{{ review.review_upvotes_count }}</td>
           </tr>
@@ -182,8 +181,7 @@
             {% if review.is_anonymous %}
             <td>匿名用户</td>
             {% else %}
-            <td><a href="{{ url_for('user.view_profile', user_id=review.author_id) }}" target="_blank">{{
-                review.author_username }}</a></td>
+            <td><a href="{{ url_for('user.view_profile', user_id=review.author_id) }}" target="_blank"><bdi>{{ review.author_username }}</bdi></a></td>
             {% endif %}
             <td>{{ review.review_upvotes_count }}</td>
             <td>{{ review.review_length }}</td>
@@ -214,7 +212,7 @@
           {% for user in users %}
 	        <tr {% if loop.index > default_show_count %}class="collapse more-users"{% endif %}>
             <th class="text-center">#{{ loop.index }}</th>
-            <td><a href="{{ url_for('user.view_profile', user_id=user.id) }}" target="_blank">{{ user.username }}</a>
+            <td><a href="{{ url_for('user.view_profile', user_id=user.id) }}" target="_blank"><bdi>{{ user.username }}</bdi></a>
             </td>
             <td>{{ user.reviews_count }}</td>
             <td>{{ user.review_upvotes_count }}</td>

--- a/app/templates/review-comments.html
+++ b/app/templates/review-comments.html
@@ -2,7 +2,7 @@
             <div class="panel-body" style="padding: 5px 15px;">
               {% for comment in review.comments %}
               <div class="ud-pd-sm solid">
-                  <a href="{{ url_for('user.view_profile', user_id=comment.author.id) }}">{{ comment.author.username }}</a>：
+                  <a href="{{ url_for('user.view_profile', user_id=comment.author.id) }}"><bdi>{{ comment.author.username }}</bdi></a>：
                   <span>{{ comment.content|content_filter|safe|urlize(nofollow=true) }}</span>
                   <span class="text-muted small float-right">
                     {% if user.is_active %}

--- a/app/templates/review-list.html
+++ b/app/templates/review-list.html
@@ -14,7 +14,7 @@
           {% if review.is_anonymous %}
           <span class="blue">匿名用户</span>
           {% else %}
-	      <a href="{{ url_for('user.view_profile', user_id=review.author.id) }}">{{ review.author.username }}</a>
+	      <a href="{{ url_for('user.view_profile', user_id=review.author.id) }}"><bdi>{{ review.author.username }}</bdi></a>
           {% endif %}
 	      {% if review.publish_time == review.update_time %}点评了{% else %}更新了点评{% endif %}
               <a href="{{ url_for('course.view_course', course_id=review.course.id) }}#review-{{ review.id }}">{{ review.course.name }}{% if review.course.teachers %}（{{ review.course.teacher_names_display|name_display_short }}）{% endif %}</a>

--- a/app/templates/teacher-profile-history.html
+++ b/app/templates/teacher-profile-history.html
@@ -43,7 +43,7 @@
       	      {% else %}暂无{% endif %}
       	    </p>
             <div>
-              <span class="text-muted">贡献者：<a href="{{ url_for('user.view_profile', user_id=history.author) }}">{{ history.author_user.username }}</a></span>
+              <span class="text-muted">贡献者：<a href="{{ url_for('user.view_profile', user_id=history.author) }}"><bdi>{{ history.author_user.username }}</bdi></a></span>
               <span class="text-muted pull-right">编辑时间：<span class="localtime" style="display: none;">{{ history.update_time|utctime }}</span></span>
             </div>
       	  </div>
@@ -58,7 +58,7 @@
 	{% if current_user.is_authenticated %}
 	<btn class="btn btn-link float-right"><a href="{{ url_for('teacher.edit_profile', teacher_id=teacher.id) }}">编辑教师信息</a></btn>
 	{% endif %}
-	<h3 class="blue">{{ teacher.name }}</h3>
+	<h3 class="blue"><bdi>{{ teacher.name }}</bdi></h3>
 	<p>{{ teacher.dept.name }}</p>
 	<p>教师主页：
           {% if teacher.homepage and teacher.homepage != 'http://' %}

--- a/app/templates/teacher-profile.html
+++ b/app/templates/teacher-profile.html
@@ -65,7 +65,7 @@
 	{% if current_user.is_authenticated %}
 	<btn class="btn btn-link float-right"><a href="{{ url_for('teacher.edit_profile', teacher_id=teacher.id) }}">编辑教师信息</a></btn>
 	{% endif %}
-	<h3 class="blue">{{ teacher.name }}</h3>
+	<h3 class="blue"><bdi>{{ teacher.name }}</bdi></h3>
 	<p>{{ teacher.dept.name }}</p>
         {% if teacher.homepage and teacher.homepage != 'http://' %}
           {% set homepages = teacher.homepage.split('\n') %}
@@ -77,18 +77,18 @@
           {% endfor %}
           {% if valid_homepages %}
             {% if valid_homepages|length == 1 %}
-            <p>教师主页：<a href="{{ valid_homepages[0] }}" target="_blank"><span class="glyphicon glyphicon-link" aria-hidden="true"></span> {{ valid_homepages[0] }}</a></p>
+            <p>教师主页：<a href="{{ valid_homepages[0] | safe_url }}" target="_blank"><span class="glyphicon glyphicon-link" aria-hidden="true"></span> <bdi>{{ valid_homepages[0] }}</bdi></a></p>
             {% else %}
             <p>教师主页：
               {% for homepage in valid_homepages %}
-              <br><a href="{{ homepage }}" target="_blank"><span class="glyphicon glyphicon-link" aria-hidden="true"></span> {{ homepage }}</a>
+              <br><a href="{{ homepage | safe_url }}" target="_blank"><span class="glyphicon glyphicon-link" aria-hidden="true"></span> <bdi>{{ homepage }}</bdi></a>
               {% endfor %}
             </p>
             {% endif %}
           {% endif %}
 	{% endif %}
 	{% if teacher.research_interest %}
-	<p>研究方向：{{ teacher.research_interest }}</p>
+	<p>研究方向：<bdi>{{ teacher.research_interest }}</bdi></p>
 	{% endif %}
       </div>
 

--- a/app/templates/teacher-settings.html
+++ b/app/templates/teacher-settings.html
@@ -5,7 +5,7 @@
   <div class="row float-element">
 
     <div class="bm-pd-lg">
-      <h3 class="blue">编辑教师信息 - {{ teacher.name }}</h3>
+      <h3 class="blue">编辑教师信息 - <bdi>{{ teacher.name }}</bdi></h3>
       <hr>
       {% if current_user.is_admin or not teacher.info_locked %}
       <p><a href="{{ url_for('teacher.profile_history', teacher_id=teacher.id) }}">查看编辑历史（共 {{ teacher.info_history_count }} 次）</a></p>

--- a/app/templates/user-reviews.html
+++ b/app/templates/user-reviews.html
@@ -6,7 +6,7 @@
 
       <div class="bm-pd-lg">
         <div class="inline-h3">
-          <span class="blue h3"><a href="{{ url_for('user.view_profile', user_id=user.id) }}">{{ user.username }}</a> 点评</span>
+          <span class="blue h3"><a href="{{ url_for('user.view_profile', user_id=user.id) }}"><bdi>{{ user.username }}</bdi></a> 点评</span>
           （{{ user.reviews_count }}门）
         </div>
 

--- a/app/utils.py
+++ b/app/utils.py
@@ -186,6 +186,75 @@ def resize_avatar(old_file):
         return new_filename
     return old_file
 
+# Invisible characters that can hide or reorder text. Two families:
+#  - zero-width / word-joiner characters used to smuggle or split text
+#  - bidirectional control/override characters used for text-direction
+#    spoofing (Trojan Source, CVE-2021-42574)
+HIDDEN_CHARS = [
+    '\u200b',  # Zero-width space
+    '\u200c',  # Zero-width non-joiner
+    '\u200d',  # Zero-width joiner
+    '\ufeff',  # Zero-width no-break space (BOM)
+    '\u2060',  # Word joiner
+    '\u180e',  # Mongolian vowel separator
+    '\u2061',  # Function application
+    '\u2062',  # Invisible times
+    '\u2063',  # Invisible separator
+    '\u2064',  # Invisible plus
+    '\u200e',  # Left-to-right mark
+    '\u200f',  # Right-to-left mark
+    '\u061c',  # Arabic letter mark
+    '\u202a',  # Left-to-right embedding
+    '\u202b',  # Right-to-left embedding
+    '\u202c',  # Pop directional formatting
+    '\u202d',  # Left-to-right override
+    '\u202e',  # Right-to-left override
+    '\u2066',  # Left-to-right isolate
+    '\u2067',  # Right-to-left isolate
+    '\u2068',  # First strong isolate
+    '\u2069',  # Pop directional isolate
+    '\u206a',  # Inhibit symmetric swapping
+    '\u206b',  # Activate symmetric swapping
+    '\u206c',  # Inhibit Arabic form shaping
+    '\u206d',  # Activate Arabic form shaping
+    '\u206e',  # National digit shapes
+    '\u206f',  # Nominal digit shapes
+]
+_HIDDEN_CHARS_TABLE = {ord(c): None for c in HIDDEN_CHARS}
+
+
+def strip_hidden_chars(text):
+    """Remove zero-width and bidirectional control characters that can be used
+    to hide or reorder text (Unicode spoofing / Trojan-Source tricks)."""
+    if not text:
+        return text
+    return text.translate(_HIDDEN_CHARS_TABLE)
+
+
+@app.template_filter('safe_url')
+def normalize_url(url):
+    """Normalize a user-supplied external URL for safe use in an href.
+
+    Only http/https are allowed; a schemeless value gets http:// prepended;
+    a value carrying any other scheme (javascript:, data:, vbscript:, ...) or
+    an otherwise unusable value becomes '' so it renders as an inert href.
+    """
+    if not url:
+        return ''
+    url = strip_hidden_chars(str(url)).strip()
+    # Browsers ignore embedded control characters inside a URL, so drop them
+    # first -- otherwise "java\tscript:alert(1)" would slip past the check.
+    url = re.sub(r'[\x00-\x1f\x7f]', '', url).strip()
+    if not url:
+        return ''
+    m = re.match(r'^([a-zA-Z][a-zA-Z0-9+.\-]*):', url)
+    if m:
+        if m.group(1).lower() not in ('http', 'https'):
+            return ''
+        return url
+    return 'http://' + url
+
+
 def sanitize(text):
     # First pass: use lxml cleaner to remove dangerous elements  
     # style=True removes ALL style attributes, preventing any CSS-based hiding
@@ -197,21 +266,9 @@ def sanitize(text):
     )
     text = cleaner.clean_html(text)
 
-    # Remove zero-width characters and other Unicode hiding tricks
-    zero_width_chars = [
-        '\u200b',  # Zero-width space
-        '\u200c',  # Zero-width non-joiner  
-        '\u200d',  # Zero-width joiner
-        '\ufeff',  # Zero-width no-break space
-        '\u2060',  # Word joiner
-        '\u180e',  # Mongolian vowel separator
-        '\u2061',  # Function application
-        '\u2062',  # Invisible times
-        '\u2063',  # Invisible separator
-        '\u2064',  # Invisible plus
-    ]
-    for char in zero_width_chars:
-        text = text.replace(char, '')
+    # Remove zero-width and bidirectional control characters
+    # (Unicode hiding / text-direction spoofing tricks).
+    text = strip_hidden_chars(text)
 
     # Apply existing image dimension removal rules
     text = re.sub(r'<img ([^>]*) style="height:[0-9]+px; width:[0-9]+px"', r'<img \1', text)
@@ -310,7 +367,7 @@ def editor_parse_at(text):
         if user:
             url = url_for('user.view_profile', user_id=user.id)
             # replace @ to Unicode char ＠ to avoid further substitution when review is edited
-            atstring = '<a href="' + url + '">' + '＠' + username + '</a>'
+            atstring = '<a href="' + url + '"><bdi>' + '＠' + username + '</bdi></a>'
             # warn: simple str.replace is wrong.
             # consider the following case: @boj @bojjenny42
             #   @boj is first matched and replaced, then the string becomes <a href="">@boj</a> <a href="">@boj</a>jenny42

--- a/app/views/api.py
+++ b/app/views/api.py
@@ -3,7 +3,7 @@ from flask_login import login_required, current_user
 from app.models import Review, ReviewComment, User, Course, ImageStore, Notification
 from app.models import ReviewCommentHistory, ThirdPartySigninHistory
 from app.forms import ReviewCommentForm
-from app.utils import rand_str, handle_upload, validate_username, validate_email
+from app.utils import rand_str, handle_upload, validate_username, validate_email, strip_hidden_chars
 from app.utils import editor_parse_at
 from app.utils import send_block_review_email, send_unblock_review_email
 from app.utils import send_review_author_profile_email
@@ -85,7 +85,7 @@ def review_new_comment():
             content = request.form.get('content')
             if len(content) > 500:
                 return jsonify(ok=False,message="评论太长了，不能超过 500 字哦")
-            content = Markup.escape(content)
+            content = Markup.escape(strip_hidden_chars(content))
             content, mentioned_users = editor_parse_at(content)
             ok,message = comment.add(review,content)
             if ok:

--- a/app/views/user.py
+++ b/app/views/user.py
@@ -2,7 +2,7 @@ from flask import Blueprint,render_template,abort,redirect,url_for,request, abor
 from app.models import *
 from app.forms import LoginForm, ProfileForm,PasswordForm
 from flask_login import login_user, current_user, login_required
-from app.utils import handle_upload, resize_avatar, sanitize, cal_validation_code
+from app.utils import handle_upload, resize_avatar, sanitize, cal_validation_code, normalize_url
 from flask_babel import gettext as _
 import re
 
@@ -105,9 +105,7 @@ def account_settings():
         else:
             user.username = username
 
-        user.homepage = form['homepage'].data.strip()
-        if not user.homepage.startswith('http'):
-            user.homepage = 'http://' + user.homepage
+        user.homepage = normalize_url(form['homepage'].data)
         user.description = form['description'].data.strip()
         if request.files.get('avatar'):
             avatar = request.files['avatar']


### PR DESCRIPTION
## Background

A user registered the username `./lee` followed by an invisible **U+200F (RIGHT-TO-LEFT MARK)**. Usernames render inline right next to the review year / star rating / term, so the bidi mark reordered the surrounding text and garbled the page. `validate_username` only rejects `@ & < > " ' :` and whitespace — and U+200F is Unicode category `Cf` (Format), which `\s` does not match — so it slipped through.

**This is a Unicode bidirectional / [Trojan-Source](https://trojansource.codes/) display issue, not XSS.** HTML metacharacters (`< > " '`) are already blocked at registration, so no markup/script can be injected. A repo-wide scan found 4 accounts with hidden control characters (RLM, RLO U+202E, and one spoofing the reserved name「匿名用户」with woven zero-width chars).

## Approach

Rather than **ban** these characters at registration (which punishes a legitimate name choice), **contain** them at render, and **strip** the dangerous ones from free-form content.

### 1. Isolate names on display — `<bdi>`
Wrap every inline render of a user-supplied name in `<bdi>` (bidirectional isolate) so embedded directional characters can no longer reorder neighbouring content. The stored username is unchanged. Sites covered:
- Reviews, profiles, followers/followings, rankings, comments, announcements, navbar dropdown, join/follow lists, the two email templates
- `User.link` / `Teacher.link` properties (notification text is built from these)
- The `@mention` link builder in `editor_parse_at` (so a mention of `./lee‏` inside a review body can't garble the body)
- User **bio** (`description`) and teacher **research-interest** / **homepage** text

### 2. Strip directional controls from content — `sanitize()`
For user *content*, the real risk is **text-direction spoofing**, which isolation can't fix. `sanitize()` already stripped zero-width characters but missed the bidi set. Centralised both in `strip_hidden_chars()` and extended it with `U+200E/200F`, `U+061C`, `U+202A–202E`, `U+2066–2069`, and the deprecated `U+206A–206F`.
- Reviews and course intro/summary/announcements flow through `sanitize()` ✔
- The **comment path bypassed `sanitize()`** entirely (only `Markup.escape`) — added the strip there.

### 3. Homepage URL scheme check
Hardened the **user** homepage against `javascript:` / `data:` hrefs (the old check was a weak `startswith('http')`). Added `normalize_url()` — allowlist `http`/`https`, prepend `http://` for schemeless input, `''` for anything else (handles mixed-case, leading-space, and embedded-control-char scheme-smuggling). Exposed as the `safe_url` Jinja filter and applied both on save and on every homepage `href` as defense-in-depth. The **teacher** homepage path already enforced an `https?://` regex.

## Not changed (flagged for maintainers)
- **Site announcements** (`Announcement.content`) and **banners** are admin-authored (`@admin` routes) and render raw HTML without `sanitize()`. Trusted authors; routing them through `sanitize()` would be harmless defense-in-depth if desired.
- Course/teacher/program **names** come from the official jw.ustc catalog, not user input — no isolation needed.
- Existing *stored* reviews/comments with bidi chars are cleaned only on next save (like the pre-existing zero-width stripping). A one-off backfill running `strip_hidden_chars` over stored rows can clean them if wanted; the `<bdi>` username fix is render-time and covers all existing usernames immediately.

## Verification
- 21/21 changed templates parse; all touched modules import cleanly.
- Real `sanitize()` strips RLO/PDF/RLM from review HTML → readable text, zero bidi controls remaining.
- `normalize_url` neutralises `javascript:` (incl. `JavaScript:`, leading-space, `java\tscript:`), `data:`, `vbscript:` → `''`; preserves http/https; prepends `http://` for schemeless.
- Header fragment renders `./lee‏` sealed inside `<bdi>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)