### PR TITLE
Check every push, and deploy master to icourse.club automatically

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,117 @@
+name: CI / Deploy
+
+# CI runs for every push and every pull request.  The deploy job runs only for
+# a push to master and only after CI has passed: `needs: ci` makes that a hard
+# gate rather than a convention -- a red check cannot reach production.
+on:
+  push:
+    branches: [master]
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  ci:
+    name: Checks
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: false          # app/static/MathJax is a large, asset-only submodule
+          persist-credentials: false
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.9'      # matches /usr/bin/python3 on the production host
+          cache: pip
+          cache-dependency-path: requirements.txt
+
+      - name: Install mysqlclient build dependencies
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends pkg-config default-libmysqlclient-dev
+
+      - name: Syntax-check every tracked Python file
+        # py_compile parses without importing, so this reaches the maintenance
+        # scripts in tests/ that the import check below never touches.
+        run: git ls-files -z '*.py' | xargs -0 -n 50 python -m py_compile
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Check for conflicting dependencies
+        run: pip check
+
+      - name: Provide a configuration for the import check
+        # config/default.py is deliberately untracked -- it holds the production
+        # SECRET_KEY, database URI and mail/API credentials.  The committed
+        # example is enough to import the application.
+        run: cp config/default.py.example config/default.py
+
+      - name: Import the application
+        # app/__init__.py ends in `from app.views import *`, so importing the
+        # package pulls in every view, model and form.  This is the check that
+        # catches a missing dependency, a bad import or a NameError at module
+        # level before it can reach production.  Nothing connects to MySQL at
+        # import time, so no database service is needed here.
+        run: |
+          PYTHONPATH=. python - <<'PY'
+          import app
+          routes = list(app.app.url_map.iter_rules())
+          print(f"imported cleanly, {len(routes)} routes registered")
+          if len(routes) < 50:
+              raise SystemExit(f"only {len(routes)} routes registered -- blueprints failed to load")
+          PY
+
+      - name: Check the migration history has a single head
+        # Two heads make `flask db upgrade` fail on the server, which would
+        # otherwise only be discovered halfway through a deploy.
+        run: |
+          heads=$(PYTHONPATH=. flask db heads 2>/dev/null | grep -cE '^[0-9a-f]{8,}') || true
+          echo "alembic heads: ${heads:-0}"
+          if [ "${heads:-0}" != "1" ]; then
+            echo "::error::expected exactly one Alembic head, found ${heads:-0}"
+            exit 1
+          fi
+
+      - name: Run the database-free test suites
+        run: |
+          PYTHONPATH=. python tests/test_search_text.py
+          PYTHONPATH=. python tests/test_search_segment.py
+
+  deploy:
+    name: Deploy to icourse.club
+    needs: ci
+    # Never runs for a pull request.  This repository is public and the runner
+    # lives on the production host, so the guard is a security boundary, not a
+    # convenience.
+    if: >-
+      (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
+      && github.ref == 'refs/heads/master'
+    runs-on: [self-hosted, icourse-prod]
+    timeout-minutes: 30
+    concurrency:
+      group: production-deploy      # one deploy at a time, never cancelled midway
+      cancel-in-progress: false
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+          submodules: false
+          persist-credentials: false
+
+      - name: Deploy and verify
+        # Deploys this exact commit -- the one CI just passed on -- rather than
+        # whatever origin/master points at by now.
+        env:
+          DEPLOY_REF: ${{ github.sha }}
+        run: ./deploy/deploy.sh
+
+      - name: Report the running revision
+        if: always()
+        run: git -C /srv/ustc-course log -1 --format='now serving %h %s'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,12 +18,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           submodules: false          # app/static/MathJax is a large, asset-only submodule
           persist-credentials: false
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v7
         with:
           python-version: '3.9'      # matches /usr/bin/python3 on the production host
           cache: pip
@@ -99,7 +99,7 @@ jobs:
       group: production-deploy      # one deploy at a time, never cancelled midway
       cancel-in-progress: false
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 1
           submodules: false

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,22 @@
 *.pyc
 __pycache__
 .*
+!.github/
 *~
 data
-config/default.py
 uploads/
 node_modules/
+
+# config/ holds the live SECRET_KEY, database URI, mail password and API keys.
+# Ignore the whole directory and re-admit only the two files meant to be
+# public, so that a stray backup -- config-backup.py, default.py.bak-<date> --
+# can never be committed to this public repository by an `git add -A`.
+config/*
+!config/__init__.py
+!config/default.py.example
+
+# Editor and ad-hoc backups, kept out for the same reason.
+*.bak
+*.bak-*
+*.orig
+nohup.out

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,0 +1,156 @@
+# Continuous deployment
+
+Every push to `master` runs the checks in `.github/workflows/ci.yml`.  If they
+pass, the same workflow deploys that exact commit to `icourse.club` and
+verifies that the site is serving.  If any step fails, the deploy reverts to the
+revision that was running before and restarts onto it.
+
+    push to master ──> CI (GitHub-hosted)  ──pass──> deploy (self-hosted, on the server)
+                             │                            │
+                           fail                         fail
+                             ▼                            ▼
+                        nothing deployed            rolled back, site restored
+
+`needs: ci` in the deploy job is the gate: a red check cannot reach production.
+
+## What CI checks
+
+Everything runs on a GitHub-hosted runner against Python 3.9, matching
+`/usr/bin/python3` on the server:
+
+* **Syntax** — `py_compile` over every tracked `.py` file, so a `SyntaxError`
+  anywhere is caught, including in the maintenance scripts under `tests/`.
+* **Dependencies** — `pip install -r requirements.txt` followed by `pip check`,
+  which catches an unresolvable or mutually incompatible pin.
+* **Imports** — `app/__init__.py` ends in `from app.views import *`, so
+  importing the package pulls in every view, model and form.  This is what
+  catches a missing dependency or a bad import.  It asserts that the blueprints
+  registered their routes; nothing connects to MySQL at import time, so CI
+  needs no database.
+* **Migrations** — that the Alembic history has exactly one head, since two
+  heads would make `flask db upgrade` fail halfway through a deploy.
+* **Tests** — `tests/test_search_text.py` and `tests/test_search_segment.py`,
+  the two suites that need no database.
+
+## What the deploy does
+
+`deploy/deploy.sh`, run as `icourse` on the server:
+
+1. Refuses to start if the working tree in `/srv/ustc-course` has uncommitted
+   changes to tracked files — a hand-edit on the server is never discarded
+   silently.
+2. Fast-forwards `/srv/ustc-course` to the commit CI passed on.  Not to
+   `origin/master`: if master moved on while CI was running, the newer commit is
+   deployed by its own run, after its own checks.
+3. Installs dependencies, but only if `requirements.txt` changed.
+4. Byte-compiles and imports the application **against the live
+   `config/default.py`**.  This is the check CI cannot perform, and it happens
+   before the service is touched: a failure here reverts the tree with the old
+   code still serving and no restart at all.
+5. Runs `flask db upgrade`, but only when the code expects a revision the
+   database is not at.
+6. Restarts `ustc-course.service` and polls the site until it answers 200
+   (`HEALTH_TIMEOUT`, 120 s by default).
+7. Requests a search-index rebuild if `app/search/` changed; the existing
+   `ustc-course-search-index.timer` picks the marker up within two minutes.
+
+Any failure after step 2 reverts the checkout to the previous commit,
+reinstalls the previous dependencies if they had changed, restarts, and
+re-checks health.
+
+### Migrations are not rolled back
+
+Code is reverted; the schema is not.  A downgrade against live data is lossy
+here — the search-cache migration, for one, recreates its tables empty — and a
+schema one revision ahead of the code is the safer of the two failures for the
+additive migrations this project uses.  When a rollback crosses a migration the
+script says so loudly and prints the exact `flask db downgrade` command, and a
+human decides.
+
+### Running it by hand
+
+    sudo -u icourse /srv/ustc-course/deploy/deploy.sh
+
+Every path is an environment variable with a production default: `APP_DIR`,
+`SERVICE`, `BRANCH`, `DEPLOY_REF`, `HEALTH_URL`, `HEALTH_TIMEOUT`, `PYTHON`,
+`FLASK`, `LOCK_FILE`, `DEPLOY_USER`.  An `flock` on `LOCK_FILE` keeps two
+deploys from overlapping.
+
+## Server setup
+
+Both steps are done once, by hand, as a user with root.
+
+### 1. The one privilege the deploy needs
+
+The deploy runs as `icourse`, which already owns `/srv/ustc-course`, so the
+only thing it cannot do on its own is restart the unit.  Grant exactly that and
+nothing else, in `/etc/sudoers.d/ustc-course-deploy` (mode `0440`):
+
+    icourse ALL=(root) NOPASSWD: /bin/systemctl restart ustc-course.service
+
+Validate before trusting it — a malformed sudoers file locks everyone out:
+
+    sudo visudo -c -f /etc/sudoers.d/ustc-course-deploy
+    sudo -u icourse sudo -n -l /bin/systemctl restart ustc-course.service
+
+`deploy.sh` checks for this privilege up front and refuses to start without it,
+rather than discovering it is missing after moving the code.
+
+### 2. The GitHub Actions runner
+
+The runner is installed under the `icourse` account, so the deploy has exactly
+the access it needs — write access to `/srv/ustc-course` and nothing more — and
+the server needs no inbound SSH.
+
+    sudo -u icourse -i
+    mkdir ~/actions-runner && cd ~/actions-runner
+    V=$(curl -fsSL https://api.github.com/repos/actions/runner/releases/latest | sed -n 's/.*"tag_name": "v\([^"]*\)".*/\1/p')
+    curl -o runner.tar.gz -L https://github.com/actions/runner/releases/download/v${V}/actions-runner-linux-x64-${V}.tar.gz
+    tar xzf runner.tar.gz && rm runner.tar.gz
+    ./config.sh --url https://github.com/USTC-iCourse/ustc-course \
+                --token <REGISTRATION_TOKEN> \
+                --name icourse-prod --labels icourse-prod --unattended
+
+Get `<REGISTRATION_TOKEN>` (valid one hour) from Settings → Actions → Runners →
+New self-hosted runner, or:
+
+    gh api -X POST repos/USTC-iCourse/ustc-course/actions/runners/registration-token --jq .token
+
+Then install it as a service so it survives reboots:
+
+    cd /home/icourse/actions-runner && sudo ./svc.sh install icourse && sudo ./svc.sh start
+    sudo ./svc.sh status
+
+The `icourse-prod` label is what `runs-on: [self-hosted, icourse-prod]` selects.
+
+### Security note
+
+This repository is **public** and the runner executes on the production host,
+so two things must stay true:
+
+* The deploy job is guarded by
+  `if: (push || workflow_dispatch) && github.ref == 'refs/heads/master'`.
+  Pull requests — including from forks — run CI on GitHub's runners only, and
+  can never reach this machine.
+* In Settings → Actions → General → *Fork pull request workflows*, set
+  **Require approval for all external contributors**.  Without it, a returning
+  contributor could open a pull request whose own edited workflow asks for
+  `runs-on: self-hosted` and have it run here.
+
+The runner account is `icourse`, not root: it can restart the application unit
+and write `/srv/ustc-course`, which is what deploying requires and no more.
+
+## Failure playbook
+
+The deploy prints why it failed and what it did about it.  If the rollback
+itself failed — the only case that needs immediate attention:
+
+    sudo journalctl -u ustc-course.service -n 100 --no-pager
+    tail -n 100 /var/log/ustc-course/ustc-course-error.log
+
+    # put the last good revision back by hand
+    sudo -u icourse git -C /srv/ustc-course reset --hard <sha>
+    sudo systemctl restart ustc-course.service
+
+`git -C /srv/ustc-course reflog` lists the revisions that were deployed, newest
+first, which is where `<sha>` comes from.

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -1,0 +1,304 @@
+#!/bin/bash
+#
+# Deploy USTC iCourse into /srv/ustc-course, verify that it serves, and roll
+# back to the previous revision if any step fails.
+#
+# Runs as the icourse user -- the owner of /srv/ustc-course -- either from the
+# GitHub Actions deploy job or by hand:
+#
+#     sudo -u icourse /srv/ustc-course/deploy/deploy.sh
+#
+# The only privileged operation is restarting the systemd unit, granted
+# narrowly in /etc/sudoers.d/ustc-course-deploy.  See deploy/README.md.
+#
+# Order of operations, and why:
+#
+#   fetch -> fast-forward -> dependencies -> compile+import -> migrate ->
+#   restart -> health check
+#
+# The compile-and-import check runs against the *production* configuration
+# before the service is touched, so a config-dependent import failure aborts
+# with the old code still serving and nothing to undo.  Migrations run before
+# the restart because they are additive: the old code tolerates the new schema
+# for the few seconds between the two, whereas new code against an old schema
+# would not.
+#
+# Everything lives in main(), called on the last line, so bash has the whole
+# script in memory before it runs -- a rollback rewrites the working tree that
+# this file may itself be running from.
+
+set -Eeuo pipefail
+
+APP_DIR=${APP_DIR:-/srv/ustc-course}
+SERVICE=${SERVICE:-ustc-course.service}
+BRANCH=${BRANCH:-master}
+DEPLOY_REF=${DEPLOY_REF:-origin/${BRANCH}}
+HEALTH_URL=${HEALTH_URL:-http://127.0.0.1:3000/}
+HEALTH_TIMEOUT=${HEALTH_TIMEOUT:-120}
+PYTHON=${PYTHON:-/usr/bin/python3}
+FLASK=${FLASK:-/home/icourse/.local/bin/flask}
+LOCK_FILE=${LOCK_FILE:-/home/icourse/.cache/ustc-course-deploy.lock}
+# The account that owns APP_DIR. Overridable so that the script can be
+# exercised against a staging checkout without impersonating icourse.
+DEPLOY_USER=${DEPLOY_USER:-icourse}
+
+STAGE="startup"
+PREV_SHA=""
+PREV_DB_REV=""
+REQS_CHANGED=0
+UPGRADE_ATTEMPTED=0
+SERVICE_RESTARTED=0
+
+log()  { printf '%s ==> %s\n'  "$(date '+%F %T')" "$*"; }
+warn() { printf '%s !!  %s\n'  "$(date '+%F %T')" "$*" >&2; }
+err()  { printf '%s ERR %s\n'  "$(date '+%F %T')" "$*" >&2; }
+
+# Give up before anything has been changed: no rollback is needed or possible.
+fail() { err "$*"; exit 1; }
+
+# Give up after the working tree has been touched: undo it.
+abort() {
+    trap - ERR
+    err "DEPLOY FAILED during '${STAGE}': $*"
+    rollback
+    exit 1
+}
+
+git_() { git -C "$APP_DIR" "$@"; }
+
+# The Alembic revision the database is actually at, empty if it has none.
+db_revision() {
+    ( cd "$APP_DIR" && PYTHONPATH=. "$FLASK" db current 2>/dev/null \
+        | grep -oE '^[0-9a-f]{8,}' | head -n1 ) || true
+}
+
+# The Alembic revision the checked-out code expects.
+code_revision() {
+    ( cd "$APP_DIR" && PYTHONPATH=. "$FLASK" db heads 2>/dev/null \
+        | grep -oE '^[0-9a-f]{8,}' | head -n1 ) || true
+}
+
+install_requirements() {
+    ( cd "$APP_DIR" && "$PYTHON" -m pip install --user --quiet \
+        --no-warn-script-location -r requirements.txt )
+}
+
+# Byte-compile, then import the application with the real production config.
+# This is what CI cannot do: CI imports against config/default.py.example,
+# while this catches anything that depends on the live configuration.
+preflight_code() {
+    ( cd "$APP_DIR" && "$PYTHON" -m compileall -q app config run.py ) || return 1
+    ( cd "$APP_DIR" && PYTHONPATH=. "$PYTHON" - <<'PY'
+import sys
+import app
+routes = len(list(app.app.url_map.iter_rules()))
+print("import ok, %d routes registered" % routes)
+if routes < 50:
+    sys.exit("only %d routes registered -- blueprints failed to load" % routes)
+PY
+    ) || return 1
+}
+
+restart_service() {
+    sudo -n /bin/systemctl restart "$SERVICE"
+}
+
+# Poll until the site answers 200, or give up.  Checks the unit as well as the
+# socket so that a unit that failed to start is reported as such rather than as
+# a connection error.
+health_check() {
+    local deadline=$((SECONDS + HEALTH_TIMEOUT)) code=""
+    log "waiting for ${HEALTH_URL} to answer 200 (up to ${HEALTH_TIMEOUT}s)"
+    while (( SECONDS < deadline )); do
+        if systemctl is-active --quiet "$SERVICE"; then
+            code=$(curl -s -o /dev/null -w '%{http_code}' --max-time 10 "$HEALTH_URL" || true)
+            if [[ "$code" == "200" ]]; then
+                log "health check passed (HTTP 200 from ${HEALTH_URL})"
+                return 0
+            fi
+        fi
+        sleep 2
+    done
+    err "health check failed after ${HEALTH_TIMEOUT}s (last HTTP status: ${code:-none})"
+    err "unit state: $(systemctl is-active "$SERVICE" 2>&1 || true)"
+    systemctl status "$SERVICE" --no-pager --lines=20 >&2 2>&1 || true
+    return 1
+}
+
+rollback() {
+    # Never abandon a rollback half-done: from here on a failing step is
+    # reported and the remaining steps still run.
+    trap - ERR
+    set +e
+    if [[ -z "$PREV_SHA" ]]; then
+        err "no rollback point was recorded; the working tree was never modified"
+        return
+    fi
+
+    local now
+    now=$(git_ rev-parse HEAD)
+    if [[ "$now" == "$PREV_SHA" ]]; then
+        log "code is already at ${PREV_SHA:0:8}; nothing to revert"
+    else
+        warn "reverting code ${now:0:8} -> ${PREV_SHA:0:8}"
+        if git_ reset --hard "$PREV_SHA"; then
+            git_ submodule update --init --recursive >/dev/null 2>&1 || true
+        else
+            err "could not revert the working tree -- NEEDS MANUAL ATTENTION"
+        fi
+        if (( REQS_CHANGED )); then
+            warn "reinstalling the previous dependency set"
+            install_requirements || err "could not reinstall previous dependencies"
+        fi
+    fi
+
+    # The schema is deliberately not downgraded.  A downgrade against live data
+    # is lossy here -- the search-cache migration, for instance, recreates its
+    # tables empty -- and is a worse outcome than a schema that is one revision
+    # ahead of the code, which the additive migrations in this project tolerate.
+    if (( UPGRADE_ATTEMPTED )); then
+        local now_rev
+        now_rev=$(db_revision)
+        if [[ "$now_rev" != "$PREV_DB_REV" ]]; then
+            err "-----------------------------------------------------------------"
+            err "THE DATABASE WAS MIGRATED AND HAS NOT BEEN ROLLED BACK."
+            err "  schema:  ${PREV_DB_REV:-none} -> ${now_rev:-unknown}"
+            err "  code:    reverted to ${PREV_SHA:0:8}"
+            err "The schema is now ahead of the running code.  This is safe for"
+            err "additive migrations but must be checked by a human.  To undo it:"
+            err "    cd ${APP_DIR} && PYTHONPATH=. ${FLASK} db downgrade ${PREV_DB_REV}"
+            err "-----------------------------------------------------------------"
+        fi
+    fi
+
+    if (( SERVICE_RESTARTED )); then
+        warn "restarting ${SERVICE} on the previous revision"
+        if restart_service && health_check; then
+            log "ROLLBACK OK -- ${PREV_SHA:0:8} is serving and healthy"
+        else
+            err "ROLLBACK FAILED -- ${SERVICE} is not healthy. Investigate now:"
+            err "    sudo journalctl -u ${SERVICE} -n 100 --no-pager"
+            err "    tail -n 100 /var/log/ustc-course/ustc-course-error.log"
+        fi
+    else
+        log "${SERVICE} was never restarted; it is still serving ${PREV_SHA:0:8}"
+    fi
+}
+
+main() {
+    mkdir -p "$(dirname "$LOCK_FILE")"
+    exec 9>"$LOCK_FILE"
+    flock -n 9 || fail "another deploy is already running (lock: ${LOCK_FILE})"
+
+    trap 'abort "unexpected error on line ${LINENO}"' ERR
+
+    STAGE="preconditions"
+    [[ "$(id -un)" == "$DEPLOY_USER" ]] \
+        || fail "must run as ${DEPLOY_USER}, not $(id -un)"
+    [[ -d "${APP_DIR}/.git" ]]     || fail "${APP_DIR} is not a git checkout"
+    [[ "$(git_ symbolic-ref --short HEAD)" == "$BRANCH" ]] \
+        || fail "${APP_DIR} is not on ${BRANCH} (on $(git_ symbolic-ref --short HEAD))"
+
+    # A dirty tree means a production change was made by hand.  Refuse rather
+    # than discard it: a fast-forward would either fail here or, after a reset,
+    # silently throw the change away.
+    local dirty
+    dirty=$(git_ status --porcelain --untracked-files=no)
+    if [[ -n "$dirty" ]]; then
+        err "${APP_DIR} has uncommitted changes to tracked files:"
+        printf '%s\n' "$dirty" >&2
+        fail "commit them upstream or revert them, then deploy again"
+    fi
+
+    # Check the one privilege this script needs up front, rather than
+    # discovering it is missing after the code has already been moved.
+    sudo -n -l /bin/systemctl restart "$SERVICE" >/dev/null 2>&1 \
+        || fail "this user may not restart ${SERVICE}; see deploy/README.md for the sudoers rule"
+
+    STAGE="fetch"
+    log "fetching origin/${BRANCH}"
+    git_ fetch --quiet origin "$BRANCH"
+
+    PREV_SHA=$(git_ rev-parse HEAD)
+    local target
+    target=$(git_ rev-parse --verify --quiet "${DEPLOY_REF}^{commit}") \
+        || fail "cannot resolve ${DEPLOY_REF}"
+
+    if [[ "$target" == "$PREV_SHA" ]]; then
+        log "already at ${PREV_SHA:0:8} -- nothing to deploy"
+        exit 0
+    fi
+    if git_ merge-base --is-ancestor "$target" "$PREV_SHA"; then
+        log "${target:0:8} is already contained in ${PREV_SHA:0:8} -- a newer commit"
+        log "was deployed while this run was queued; nothing to do"
+        exit 0
+    fi
+    git_ merge-base --is-ancestor "$PREV_SHA" "$target" \
+        || fail "${target:0:8} is not a fast-forward from ${PREV_SHA:0:8}; refusing"
+
+    log "deploying ${PREV_SHA:0:8} -> ${target:0:8}"
+    git_ --no-pager log --oneline "${PREV_SHA}..${target}" | sed 's/^/      /'
+    PREV_DB_REV=$(db_revision)
+    log "database is at Alembic revision ${PREV_DB_REV:-none}"
+
+    STAGE="checkout"
+    git_ merge --ff-only "$target" >/dev/null
+    if ! git_ diff --quiet "$PREV_SHA" HEAD -- .gitmodules app/static/MathJax; then
+        log "submodule reference changed; updating submodules"
+        git_ submodule update --init --recursive
+    fi
+
+    STAGE="dependencies"
+    if git_ diff --quiet "$PREV_SHA" HEAD -- requirements.txt; then
+        log "requirements.txt unchanged; skipping pip"
+    else
+        log "requirements.txt changed; installing dependencies"
+        REQS_CHANGED=1
+        install_requirements || abort "pip install failed"
+    fi
+
+    STAGE="pre-flight checks"
+    log "byte-compiling and importing the application against the live config"
+    preflight_code || abort "the new code does not compile or import"
+
+    STAGE="database migration"
+    local want
+    want=$(code_revision)
+    if [[ -n "$want" && "$want" == "$PREV_DB_REV" ]]; then
+        log "database already at ${want}; no migration needed"
+    else
+        log "migrating database ${PREV_DB_REV:-none} -> ${want:-head}"
+        UPGRADE_ATTEMPTED=1
+        ( cd "$APP_DIR" && PYTHONPATH=. "$FLASK" db upgrade ) || abort "flask db upgrade failed"
+        log "database now at $(db_revision)"
+    fi
+
+    STAGE="restart"
+    log "restarting ${SERVICE}"
+    SERVICE_RESTARTED=1
+    restart_service || abort "systemctl restart failed"
+
+    STAGE="health check"
+    health_check || abort "the new revision is not serving"
+
+    STAGE="post-deploy"
+    # The catalogue index has no freshness overlay, so a change to the search
+    # code needs a rebuild.  request_rebuild() only drops a marker file; the
+    # existing ustc-course-search-index.timer picks it up within two minutes.
+    if ! git_ diff --quiet "$PREV_SHA" HEAD -- app/search/; then
+        log "app/search/ changed; requesting an index rebuild"
+        ( cd "$APP_DIR" && PYTHONPATH=. "$PYTHON" - <<'PY'
+from app import app
+from app.search.builder import request_rebuild
+for collection in ("courses", "reviews"):
+    request_rebuild(app, collection)
+print("rebuild requested for courses and reviews")
+PY
+        ) || warn "could not request an index rebuild; the daily timer will catch up"
+    fi
+
+    trap - ERR
+    log "DEPLOY OK -- ${APP_DIR} is serving ${target:0:8} ($(git_ log -1 --format=%s))"
+}
+
+main "$@"

--- a/gunicorn_config.py
+++ b/gunicorn_config.py
@@ -1,6 +1,4 @@
 # Gunicorn configuration file
-import logging
-import sys
 
 # Bind to localhost
 bind = "127.0.0.1:3000"
@@ -13,10 +11,13 @@ accesslog = "/var/log/ustc-course/ustc-course-access.log"
 errorlog = "/var/log/ustc-course/ustc-course-error.log"
 loglevel = "info"
 
-# Capture print statements and errors
+# Capture stray print()/stderr from the app into the error log (safety net).
 capture_output = True
 
-# Log to stdout as well (for systemd journal)
+# Send access logs and error/app logs to SEPARATE files.
+# access -> access_file, error/app -> error_file. No console handler:
+# under capture_output the process stdout/stderr is already redirected to
+# the error log, so a console handler would just duplicate everything there.
 logconfig_dict = {
     'version': 1,
     'disable_existing_loggers': False,
@@ -25,35 +26,39 @@ logconfig_dict = {
             'format': '%(asctime)s [%(process)d] [%(levelname)s] %(message)s',
             'datefmt': '[%Y-%m-%d %H:%M:%S %z]',
             'class': 'logging.Formatter'
+        },
+        'access': {
+            # gunicorn's access_log_format already includes time/status/etc.
+            'format': '%(message)s',
+            'class': 'logging.Formatter'
         }
     },
     'handlers': {
-        'console': {
-            'class': 'logging.StreamHandler',
-            'formatter': 'generic',
-            'stream': sys.stdout
-        },
         'error_file': {
             'class': 'logging.FileHandler',
             'formatter': 'generic',
             'filename': errorlog
+        },
+        'access_file': {
+            'class': 'logging.FileHandler',
+            'formatter': 'access',
+            'filename': accesslog
         }
     },
     'root': {
         'level': 'INFO',
-        'handlers': ['console', 'error_file']
+        'handlers': ['error_file']
     },
     'loggers': {
         'gunicorn.error': {
             'level': 'INFO',
-            'handlers': ['console', 'error_file'],
+            'handlers': ['error_file'],
             'propagate': False
         },
         'gunicorn.access': {
             'level': 'INFO',
-            'handlers': ['console'],
+            'handlers': ['access_file'],
             'propagate': False
         }
     }
 }
-


### PR DESCRIPTION
Sets up CI and continuous deployment for the site, which had neither: deploys
were a documented sequence of `cp` and `systemctl` run by hand, and nothing
checked a commit before it ran on the server.

## How it fits together

```
push to master ──> CI (GitHub-hosted) ──pass──> deploy (self-hosted, on the server)
                          │                            │
                        fail                         fail
                          ▼                            ▼
                   nothing deployed             rolled back, site restored
```

`needs: ci` is the gate: a red check cannot reach production.

## CI

On a GitHub-hosted runner at Python 3.9, matching `/usr/bin/python3` on the server:

- **Syntax** — `py_compile` over all 96 tracked `.py` files, so a `SyntaxError` anywhere is caught, including in the maintenance scripts under `tests/`.
- **Dependencies** — `pip install -r requirements.txt` then `pip check`, for an unresolvable or mutually incompatible pin.
- **Imports** — `app/__init__.py` ends in `from app.views import *`, so importing the package pulls in every view, model and form. This is what catches a missing dependency or a bad import; it asserts the blueprints registered their routes. Nothing connects to MySQL at import time, so CI needs no database.
- **Migrations** — that Alembic has exactly one head, since two would fail `flask db upgrade` halfway through a deploy.
- **Tests** — the two search suites that need no database.

## Deployment

Runs only after CI passes, and only for master. It deploys **the commit CI passed on**, not whatever `origin/master` points at by then, so a commit that landed while CI was running is deployed by its own run after its own checks.

`deploy/deploy.sh` orders the work so most failures cost nothing:

1. Refuses to start if `/srv/ustc-course` has uncommitted changes to tracked files — a hand-edit on the server is never discarded silently.
2. Fast-forwards, installs dependencies only if `requirements.txt` changed.
3. Byte-compiles and imports **against the live `config/default.py`** — the check CI cannot do — *before the service is touched*, so a config-dependent failure reverts the tree with the old code still serving and no restart at all.
4. `flask db upgrade`, only when the code expects a revision the database is not at. Migrations run before the restart because they are additive: old code tolerates the new schema for those seconds, where new code against an old schema would not.
5. Restarts and polls until the site answers 200.

Any failure after step 2 reverts the checkout, reinstalls the previous dependencies if they had changed, restarts, and re-checks health.

**Schemas are deliberately not downgraded.** A downgrade against live data is lossy here — the search-cache migration recreates its tables empty — so the script reports the exact `flask db downgrade` command and leaves the decision to a human.

## Verified, not just reviewed

Exercised against a staging checkout and a disposable systemd unit:

| case | result |
|---|---|
| clean deploy | succeeds, health check passes |
| commit with a `SyntaxError` | aborts at pre-flight; the unit's start timestamp is **unchanged**, proving it was never restarted |
| revision that imports but does not serve | reverted, restarted, confirmed healthy again |
| older commit arriving after a newer deploy | no-op, exit 0 — not a spurious failure |

## Security

The runner runs as `icourse`, which already owns `/srv/ustc-course`, so the server needs no inbound SSH and the only added privilege is restarting one unit.

This repository is **public** and the runner sits on the production host, so the deploy job is guarded to pushes on master: pull requests, including from forks, run CI on GitHub's runners and can never reach the machine. `deploy/README.md` covers setup and the fork-approval setting that backs the guard up.

## Two fixes this depends on

- **`.gitignore`** listed only the exact path `config/default.py`. Two files beside it on the server — `config/config-backup.py` and `config/default.py.bak-<date>` — matched no pattern and both carry the live `SECRET_KEY`, database URI, mail password, OpenAI key and Turnstile secret. One `git add -A` would have published them to this public repo. Now `config/` is ignored wholesale with only the two public files re-admitted. (The existing `.*` rule would also have hidden `.github/`, so that is admitted explicitly.) No live credential is in the history — every current secret was checked against all 21 revisions that touched `config/default.py` before it was untracked.
- **`gunicorn_config.py`** running in production since 20 July was never committed, leaving a modified tracked file in `/srv/ustc-course` that automated pulls would abort on or silently discard. Committed byte-for-byte as it runs.

## Before merging

`deploy/README.md` has the details; the server needs the sudoers rule and the runner registered, or the deploy job will queue with nothing to run it.